### PR TITLE
Bugfix to log and err handler

### DIFF
--- a/dbconn/reload_password.go
+++ b/dbconn/reload_password.go
@@ -46,7 +46,7 @@ func (r *repo) ReloadPassword(ctx context.Context, currentDSN string) string {
 		blip.Debug("error parsing DSN %s: %s", currentDSN, err)
 		return ""
 	}
-	blip.Debug("old dsn: %+v", cfg)
+	blip.Debug("old dsn: %+v", RedactedDSN(currentDSN))
 
 	v, ok := r.m.Load(cfg.Addr)
 	if !ok {

--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -159,7 +159,7 @@ func (e *Engine) Prepare(ctx context.Context, plan blip.Plan, before, after func
 	err := e.db.PingContext(dbctx)
 	cancel()
 	if err != nil {
-		lerr = fmt.Errorf("while connecting to MySQL: %s", lerr)
+		lerr = fmt.Errorf("while connecting to MySQL: %s", err)
 		return lerr
 	}
 


### PR DESCRIPTION
reload_password.go was writing the password to debug logs. Now redacted.

Fixed a bug in engine. Prepare err handler, where it referenced the wrong err, masking the actual error.