### PR TITLE
plan/plan_loader: return deep copy of blip.Plan from Plan

### DIFF
--- a/plan/plan_loader.go
+++ b/plan/plan_loader.go
@@ -312,6 +312,8 @@ func (pl *Loader) Plan(monitorId string, planName string, db *sql.DB) (blip.Plan
 	}
 
 	blip.Debug("%s: loading plan %s from %s", monitorId, planName, pm.source)
+	// Since blip.Plan has field types that pass by reference (maps and slices), we want to the returned plan to
+	// be a deep copy to ensure the caller cannot modify the original shared plan.
 	return deepcopyPlan(&pm.plan)
 }
 

--- a/plan/plan_loader_test.go
+++ b/plan/plan_loader_test.go
@@ -1,8 +1,9 @@
 // Copyright 2022 Block, Inc.
 
-package plan
+package plan_test
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -12,7 +13,11 @@ import (
 
 	"github.com/cashapp/blip"
 	//"github.com/cashapp/blip/dbconn"
+
+	"github.com/cashapp/blip/metrics"
+	"github.com/cashapp/blip/plan"
 	"github.com/cashapp/blip/proto"
+	"github.com/cashapp/blip/test/mock"
 	//	"github.com/cashapp/blip/test"
 )
 
@@ -25,7 +30,7 @@ const (
 func TestLoadDefault(t *testing.T) {
 	cfg := blip.DefaultConfig(false)
 
-	pl := NewLoader(nil)
+	pl := plan.NewLoader(nil)
 	if err := pl.LoadShared(cfg.Plans, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +57,7 @@ func TestLoadOneFile(t *testing.T) {
 		Monitors: []blip.ConfigMonitor{},
 	}
 
-	pl := NewLoader(nil)
+	pl := plan.NewLoader(nil)
 	if err := pl.LoadShared(cfg.Plans, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -67,64 +72,80 @@ func TestLoadOneFile(t *testing.T) {
 	assert.Equal(t, gotPlans, expectPlans)
 }
 
-func TestPlan_ShouldReturnDeepCopyOfPlan(t *testing.T) {
-	pl := NewLoader(
-		func(blip.ConfigPlans) ([]blip.Plan, error) { return []blip.Plan{}, nil },
-	)
+// TestPlanShouldReturnDeepCopyOfPlan needs to ensure that the copy of blip.Plan returned is
+// indeed a deep copy of the struct with new copies of all reference types created, such as
+// slice and  map fields. This is important because the plan_loader cannot control what callers
+// do with the blip.Plan as they sometimes need to modify to do effective work. A real world
+// example of this would be that the level_collecter logic needs to sort the plan and aggregate
+// metrics into levels across divisible freqencies. If the same plan needs to be changed again
+// , say by the level_adjuster, then the returned plan, if it is not a deep copy, would contain
+// metrics with aggregations that were not part of the original plan. If this modified plan were
+// to be passed to the level_collector again , the resulting behavior would be considered
+// undefined and in this example would introduce bugs such as duplicate metrics.
+func TestPlanShouldReturnDeepCopyOfPlan(t *testing.T) {
+	mc := mock.MetricsCollector{
+		CollectFunc: func(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+			return nil, nil
+		},
+	}
+	mf := mock.MetricFactory{
+		MakeFunc: func(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+			return mc, nil
+		},
+	}
+	metrics.Register(mc.Domain(), mf) // MUST CALL FIRST, before the rest...
+
 	planName := "foobar"
-	pl.sharedPlans = []planMeta{
-		{
-			name: planName,
-			plan: blip.Plan{
-				Levels: map[string]blip.Level{
-					"l1": {
-						Name: "l1",
-						Freq: "1s",
-						Collect: map[string]blip.Domain{
-							"d1": {
-								Name:    "d1",
-								Metrics: []string{"m1"},
-							},
-						},
+	expected := blip.Plan{
+		Name: planName,
+		Levels: map[string]blip.Level{
+			"l1": {
+				Name: "l1",
+				Freq: "1s",
+				Collect: map[string]blip.Domain{
+					"test": {
+						Name:    "d1",
+						Metrics: []string{"m1"},
 					},
-					"l2": {
-						Name: "l2",
-						Freq: "5s",
-						Collect: map[string]blip.Domain{
-							"d1": {
-								Name:    "d1",
-								Metrics: []string{"m2"},
-							},
-						},
+				},
+			},
+			"l2": {
+				Name: "l2",
+				Freq: "5s",
+				Collect: map[string]blip.Domain{
+					"test": {
+						Name:    "d1",
+						Metrics: []string{"m2"},
 					},
 				},
 			},
 		},
 	}
+	pl := plan.NewLoader(
+		func(blip.ConfigPlans) ([]blip.Plan, error) {
+			return []blip.Plan{expected}, nil
+		})
+	err := pl.LoadShared(blip.ConfigPlans{}, nil)
+	require.NoError(t, err)
 
 	got, err := pl.Plan("", planName, nil)
 	require.NoError(t, err)
 
-	expected := pl.sharedPlans[0].plan
 	assert.Equal(t, expected, got)
-	verifyDeepCopy(t, expected, got)
-}
-
-// verifyDeepCopy verifies is a is a deep copy of b by comparing address of the slices and maps in blip.Plan.
-// This solution is not ideal, but there really isn't a good way to compare reference object addresses in go.
-// The converse is to attempt to mutate the slices and maps embedded within blip.Plan, but even more verbose.
-func verifyDeepCopy(t *testing.T, a, b blip.Plan) {
+	// Verify that is a is a deep copy of b by comparing address of the slices and maps in blip.Plan.
+	// This solution is not ideal, but there really isn't a good way to compare reference object addresses in go.
+	// The converse is to attempt to mutate the slices and maps embedded within blip.Plan, but even more verbose.
 	// Verify top level map.
-	assert.NotEqual(t, fmt.Sprintf("%p", a.Levels), fmt.Sprintf("%p", b.Levels))
-	for levelKey, aLevel := range a.Levels {
+	assert.NotEqual(t, fmt.Sprintf("%p", expected.Levels), fmt.Sprintf("%p", got.Levels))
+	for levelKey, expectedLevel := range expected.Levels {
 		// Verify domain maps.
-		aCollect := aLevel.Collect
-		bCollect := b.Levels[levelKey].Collect
-		assert.NotEqual(t, fmt.Sprintf("%p", aCollect), fmt.Sprintf("%p", bCollect))
-		for aDomainKey, aDomain := range aCollect {
+		expectedCollect := expectedLevel.Collect
+		gotCollect := got.Levels[levelKey].Collect
+		assert.NotEqual(t, fmt.Sprintf("%p", expectedCollect), fmt.Sprintf("%p", gotCollect))
+		for domainKey, expectedDomain := range expectedCollect {
 			// Verify slice of metrics to collect.
-			bDomain := bCollect[aDomainKey]
-			assert.NotEqual(t, fmt.Sprintf("%p", aDomain.Metrics), fmt.Sprintf("%p", bDomain.Metrics))
+			gotDomain := gotCollect[domainKey]
+			assert.NotEqual(t, fmt.Sprintf("%p", expectedDomain.Metrics), fmt.Sprintf("%p", gotDomain.Metrics))
 		}
 	}
 }

--- a/plan/plan_loader_test.go
+++ b/plan/plan_loader_test.go
@@ -1,16 +1,17 @@
 // Copyright 2022 Block, Inc.
 
-package plan_test
+package plan
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cashapp/blip"
 	//"github.com/cashapp/blip/dbconn"
-	"github.com/cashapp/blip/plan"
 	"github.com/cashapp/blip/proto"
 	//	"github.com/cashapp/blip/test"
 )
@@ -24,7 +25,7 @@ const (
 func TestLoadDefault(t *testing.T) {
 	cfg := blip.DefaultConfig(false)
 
-	pl := plan.NewLoader(nil)
+	pl := NewLoader(nil)
 	if err := pl.LoadShared(cfg.Plans, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +52,7 @@ func TestLoadOneFile(t *testing.T) {
 		Monitors: []blip.ConfigMonitor{},
 	}
 
-	pl := plan.NewLoader(nil)
+	pl := NewLoader(nil)
 	if err := pl.LoadShared(cfg.Plans, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -64,4 +65,66 @@ func TestLoadOneFile(t *testing.T) {
 		},
 	}
 	assert.Equal(t, gotPlans, expectPlans)
+}
+
+func TestPlan_ShouldReturnDeepCopyOfPlan(t *testing.T) {
+	pl := NewLoader(
+		func(blip.ConfigPlans) ([]blip.Plan, error) { return []blip.Plan{}, nil },
+	)
+	planName := "foobar"
+	pl.sharedPlans = []planMeta{
+		{
+			name: planName,
+			plan: blip.Plan{
+				Levels: map[string]blip.Level{
+					"l1": {
+						Name: "l1",
+						Freq: "1s",
+						Collect: map[string]blip.Domain{
+							"d1": {
+								Name:    "d1",
+								Metrics: []string{"m1"},
+							},
+						},
+					},
+					"l2": {
+						Name: "l2",
+						Freq: "5s",
+						Collect: map[string]blip.Domain{
+							"d1": {
+								Name:    "d1",
+								Metrics: []string{"m2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := pl.Plan("", planName, nil)
+	require.NoError(t, err)
+
+	expected := pl.sharedPlans[0].plan
+	assert.Equal(t, expected, got)
+	verifyDeepCopy(t, expected, got)
+}
+
+// verifyDeepCopy verifies is a is a deep copy of b by comparing address of the slices and maps in blip.Plan.
+// This solution is not ideal, but there really isn't a good way to compare reference object addresses in go.
+// The converse is to attempt to mutate the slices and maps embedded within blip.Plan, but even more verbose.
+func verifyDeepCopy(t *testing.T, a, b blip.Plan) {
+	// Verify top level map.
+	assert.NotEqual(t, fmt.Sprintf("%p", a.Levels), fmt.Sprintf("%p", b.Levels))
+	for levelKey, aLevel := range a.Levels {
+		// Verify domain maps.
+		aCollect := aLevel.Collect
+		bCollect := b.Levels[levelKey].Collect
+		assert.NotEqual(t, fmt.Sprintf("%p", aCollect), fmt.Sprintf("%p", bCollect))
+		for aDomainKey, aDomain := range aCollect {
+			// Verify slice of metrics to collect.
+			bDomain := bCollect[aDomainKey]
+			assert.NotEqual(t, fmt.Sprintf("%p", aDomain.Metrics), fmt.Sprintf("%p", bDomain.Metrics))
+		}
+	}
 }


### PR DESCRIPTION
The `blip.Plan` returned by `PlanLoader.Plan` was a shallow copy. Which introduces the behavior where duplicate metrics are created when `ChangePlan` is called more than once. Using a deep copy fixes this issue.