### PR TITLE
Parse password from cnf file

### DIFF
--- a/dbconn/mycnf.go
+++ b/dbconn/mycnf.go
@@ -17,14 +17,9 @@ func ParseMyCnf(file string) (blip.ConfigMySQL, error) {
 		return blip.ConfigMySQL{}, err
 	}
 
-	// DO NOT copy password from my.cnf into Blip config.M.password.
-	// In Password() (factory.go), if config.M.my-cnf is set, it reads
-	// the password from there. config.M.password is the last options
-	// because we want to keep passwords out of Blip files--they should
-	// be stored and managed by something more secure.
 	cfg := blip.ConfigMySQL{
 		Username: mycnf.Section("client").Key("user").String(),
-		// Password: mycnf.Section("client").Key("password").String(),
+		Password: mycnf.Section("client").Key("password").String(),
 		Hostname: mycnf.Section("client").Key("host").String(),
 		Socket:   mycnf.Section("client").Key("socket").String(),
 	}

--- a/dbconn/mycnf_test.go
+++ b/dbconn/mycnf_test.go
@@ -18,7 +18,7 @@ func TestParseMyCnf(t *testing.T) {
 	}
 	expect := blip.ConfigMySQL{
 		Username: "U",
-		Password: "", // correct, see code comments in ParseMyCnf
+		Password: "P",
 		Hostname: "H:33560",
 		TLSCA:    "CA",
 		TLSCert:  "CERT",


### PR DESCRIPTION
### Note
Got access denied error when providing cnf file for blip config. Fix it by parsing password from cnf file

### Testing
Pointed to local blip for testing and access denied error was gone.