### PR TITLE
Add event.trx collector

### DIFF
--- a/metrics/event.trx/trx.go
+++ b/metrics/event.trx/trx.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Block, Inc.
+
+package eventtrx
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"strconv"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/sqlutil"
+)
+
+const (
+	DOMAIN           = "event.trx"
+	OLDEST_TRX_QUERY = `SELECT UNIX_TIMESTAMP(NOW()) - UNIX_TIMESTAMP(MIN(trx_started)) AS time FROM information_schema.innodb_trx;`
+)
+
+type trxMetrics struct {
+	queryOldest bool
+}
+
+// Trx collects metrics for the event.trx domain.
+// The source is information_schema.innodb_trx.
+type Trx struct {
+	db      *sql.DB
+	atLevel map[string]trxMetrics
+}
+
+// Verify collector implements blip.Collector interface
+var _ blip.Collector = &Trx{}
+
+// NewTrx makes a new Trx collector.
+func NewTrx(db *sql.DB) *Trx {
+	return &Trx{
+		db:      db,
+		atLevel: map[string]trxMetrics{},
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (c *Trx) Domain() string {
+	return DOMAIN
+}
+
+// Help returns the output for blip --print-domains.
+func (c *Trx) Help() blip.CollectorHelp {
+	return blip.CollectorHelp{
+		Domain:      DOMAIN,
+		Description: "Event transaction metrics from information_schema.innodb_trx",
+		Options:     map[string]blip.CollectorHelpOption{},
+		Metrics: []blip.CollectorMetric{
+			{
+				Name: "oldest",
+				Type: blip.GAUGE,
+				Desc: "The time of oldest transaction in seconds",
+			},
+		},
+	}
+}
+
+// Prepare prepares the collector for the given plan.
+func (c *Trx) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+LEVEL:
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[DOMAIN]
+		if !ok {
+			continue LEVEL // not collected at this level
+		}
+
+		if len(dom.Metrics) == 0 {
+			return nil, fmt.Errorf("no metrics specified, expect at least one collector metric (run 'blip --print-domains' to list collector metrics)")
+		}
+
+		m := trxMetrics{}
+		for i := range dom.Metrics {
+			switch dom.Metrics[i] {
+			case "oldest":
+				m.queryOldest = true
+			default:
+				return nil, fmt.Errorf("invalid collector metric: %s (run 'blip --print-domains' to list collector metrics)", dom.Metrics[i])
+			}
+		}
+
+		c.atLevel[level.Name] = m
+	}
+
+	return nil, nil
+}
+
+// Collect collects metrics at the given level.
+func (c *Trx) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	rm, ok := c.atLevel[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	res, err := sqlutil.RowToMap(ctx, c.db, OLDEST_TRX_QUERY)
+	if err != nil {
+		return nil, fmt.Errorf("%s failed: %s", OLDEST_TRX_QUERY, err)
+	}
+
+	metrics := []blip.MetricValue{}
+	if rm.queryOldest {
+		t := float64(0)
+		if time, ok := res["time"]; ok {
+			t, _ = strconv.ParseFloat(time, 64)
+			// the only error expecting is when "NULL" is encountered
+		}
+
+		m := blip.MetricValue{
+			Name:  "oldest",
+			Type:  blip.GAUGE,
+			Value: t,
+		}
+		metrics = append(metrics, m)
+	}
+
+	return metrics, nil
+}

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cashapp/blip"
 	"github.com/cashapp/blip/metrics/aws.rds"
+	"github.com/cashapp/blip/metrics/event.trx"
 	"github.com/cashapp/blip/metrics/innodb"
 	"github.com/cashapp/blip/metrics/percona"
 	"github.com/cashapp/blip/metrics/repl"
@@ -225,6 +226,8 @@ func (f *factory) Make(domain string, args blip.CollectorFactoryArgs) (blip.Coll
 			return nil, err
 		}
 		return awsrds.NewRDS(awsrds.NewCloudWatchClient(awsConfig)), nil
+	case "event.trx":
+		return eventtrx.NewTrx(args.DB), nil
 	case "innodb":
 		return innodb.NewInnoDB(args.DB), nil
 	case "percona.response-time":
@@ -249,6 +252,7 @@ func (f *factory) Make(domain string, args blip.CollectorFactoryArgs) (blip.Coll
 // the same domain in the switch statement above (in factory.Make).
 var builtinCollectors = []string{
 	"aws.rds",
+	"event.trx",
 	"innodb",
 	"percona.response-time",
 	"repl",


### PR DESCRIPTION
### Note
Add `event.trx` domain which contains `oldest` metric
Jira ticket: https://jira.sqprod.co/browse/SPIN-3539

### Testing
Tested against my local mysql
1. add config files:

blip.yaml
  ```
plans:
  files:
    - plan.yaml
monitors:
  - id: test1
    hostname: 127.0.0.1
    username: blip
    meta:
      repl-source: 127.0.0.1
  ```
  plan.yaml
  ```
---
performance:
  freq: 5s
  collect:
    event.trx:
      metrics:
        - oldest
  ```
2. run blip
```
cd ./blip/bin/blip
./blip
```
3. Blip print following line
```
blip 0.0.0
in 412.404µs: map[event.trx:[{Name:oldest Value:0 Type:2 Group:map[] Meta:map[]}]]
```
