### PR TITLE
Fix configuration env interpolation with special characters

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func interpolateEnv(v string) string {
 	if v2 == "" && m[2] != "" {
 		return m[3]
 	}
-	return envvar.ReplaceAllString(v, v2)
+	return envvar.ReplaceAllLiteralString(v, v2)
 }
 
 // setBool sets c to the value of b if c is nil (not set). Pointers are required

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,9 @@
 package blip_test
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -28,4 +31,28 @@ func TestDefaultConfig(t *testing.T) {
 	// The default config should have minimal config with default values.
 	//expect := blip.Config{}
 	//assert.Equal(t, got, expect)
+}
+
+// TestEnvInterpolation verifies that env vars with special characters, most notably $, are properly interpolated
+func TestEnvInterpolation(t *testing.T) {
+	envKey := "blip_test_TestEnvInterpolation"
+	envVal := "a$1b!@#$%^&*()-+={};\""
+	defer os.Unsetenv(envKey)
+
+	err := os.Setenv(envKey, envVal)
+	require.Nil(t, err)
+
+	cfg := blip.Config{MySQL: blip.ConfigMySQL{Password: fmt.Sprintf("${%s}", envKey)}}
+	cfg.InterpolateEnvVars()
+	assert.Equal(t, envVal, cfg.MySQL.Password)
+}
+
+// TestEnvInterpolationEmpty verifies that a config like ${FOO:-bar} without FOO set, evaluates to "bar"
+func TestEnvInterpolationEmpty(t *testing.T) {
+	envKey := "blip_test_TestEnvInterpolation"
+	_ = os.Unsetenv(envKey)
+
+	cfg := blip.Config{MySQL: blip.ConfigMySQL{Password: fmt.Sprintf("${%s:-bar}", envKey)}}
+	cfg.InterpolateEnvVars()
+	assert.Equal(t, "bar", cfg.MySQL.Password)
 }


### PR DESCRIPTION
Environment variables referenced in the configuration file such as ${MYSQL_PASSWORD} were not properly interpolated if they contained a dollar sign $ character. These are now handled correctly.