### PR TITLE
Fix bug in Percona QRT collector and update log sink to include Meta KVs for metrics

### DIFF
--- a/metrics/percona/qrt.go
+++ b/metrics/percona/qrt.go
@@ -64,6 +64,7 @@ func NewQRT(db *sql.DB) *QRT {
 		db:          db,
 		percentiles: map[string]map[float64]float64{},
 		optional:    map[string]bool{},
+		flushQrt:    map[string]bool{},
 		available:   true,
 	}
 }

--- a/sink/log.go
+++ b/sink/log.go
@@ -5,6 +5,7 @@ package sink
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cashapp/blip"
@@ -27,7 +28,17 @@ func (s logSink) Send(ctx context.Context, m *blip.Metrics) error {
 	fmt.Printf("# duration: %d ms\n", m.End.Sub(m.Begin).Milliseconds())
 	for domain, values := range m.Values {
 		for i := range values {
-			fmt.Printf("%s.%s = %d\n", domain, values[i].Name, int64(values[i].Value))
+			metricStr := fmt.Sprintf("%s.%s = %d", domain, values[i].Name, int64(values[i].Value))
+			var metaKVs []string
+			for metaKey, metaValue := range values[i].Meta {
+				metaKV := fmt.Sprintf("%s=%s", metaKey, metaValue)
+				metaKVs = append(metaKVs, metaKV)
+			}
+			metaStr := strings.Join(metaKVs, ",")
+			if len(metaKVs) > 0 {
+				metricStr = fmt.Sprintf("%s (meta: %s)", metricStr, metaStr)
+			}
+			fmt.Println(metricStr)
 		}
 	}
 	fmt.Println()


### PR DESCRIPTION
This fixes a bug in the Percona QRT collector.

Also adds Meta KVs in the log sink.

This can be tested with the following config files:

```
# blip.yml
mysql:
  username: root
  password: test
plans:
  files:
    - plan.yml
monitors:
  - id: kpi
    hostname: "localhost:33900"
```

```
# plan.yml    

---
kpi:
  freq: 5s
  collect:
    percona.response-time:
      options:
        optional: no
        # emitted metrics will be of the form
        # query_response_pctl50
        # ...
        # query_response_pctl999
        percentiles: "50,75,90,99,99.9"
    status.global:
      metrics:
        - queries
        - threads_running
```

Then run: 

```
cd ./blip/test/docker
docker-compose up
```
to run the mysql servers.

Once the mysql servers are up and running, enable the QRT metrics in the percona server with:

```
$ mysql -P 33900 -u root --protocol tcp -ptest
mysql> INSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT SONAME 'query_response_time.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN QUERY_RESPONSE_TIME SONAME 'query_response_time.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN QUERY_RESPONSE_TIME_READ SONAME 'query_response_time.so';
Query OK, 0 rows affected (0.01 sec)

mysql> INSTALL PLUGIN QUERY_RESPONSE_TIME_WRITE SONAME 'query_response_time.so';
Query OK, 0 rows affected (0.00 sec)
```

Now start blip:

```
cd ./blip/bin/blip
go build .
./blip --config blip.yml --plans plan.yml
```

You should see the following (similar) in the log:

```
2022/07/15 10:33:55.521932 DEBUG engine.go:251 collecting plan plan.yml level kpi
# monitor:  kpi
# plan:     plan.yml
# level:    kpi
# ts:       2022-07-15T10:33:55.522005+10:00
# duration: 3 ms
status.global.queries = 338
status.global.threads_running = 1
percona.response-time.response_time = -9223372036854775808 (meta: p50=NaN)
percona.response-time.response_time = -9223372036854775808 (meta: p75=NaN)
percona.response-time.response_time = -9223372036854775808 (meta: p90=NaN)
percona.response-time.response_time = -9223372036854775808 (meta: p99=NaN)
percona.response-time.response_time = -9223372036854775808 (meta: p999=NaN)
```
        