### PR TITLE
Pass TransformMetrics down to LevelCollector

### DIFF
--- a/monitor/loader.go
+++ b/monitor/loader.go
@@ -77,6 +77,7 @@ func NewLoader(args LoaderArgs) *Loader {
 	return &Loader{
 		cfg:        args.Config,
 		factory:    args.Factories,
+		plugin:     args.Plugins,
 		planLoader: args.PlanLoader,
 		rdsLoader:  args.RDSLoader,
 		// --
@@ -436,10 +437,11 @@ func (ml *Loader) makeMonitor(cfg blip.ConfigMonitor) (*Monitor, error) {
 	}
 
 	mon := NewMonitor(MonitorArgs{
-		Config:     cfg,
-		DbMaker:    ml.factory.DbConn,
-		PlanLoader: ml.planLoader,
-		Sinks:      sinks,
+		Config:          cfg,
+		DbMaker:         ml.factory.DbConn,
+		PlanLoader:      ml.planLoader,
+		Sinks:           sinks,
+		TransformMetric: ml.plugin.TransformMetrics,
 	})
 	return mon, nil
 }

--- a/monitor/loader_test.go
+++ b/monitor/loader_test.go
@@ -50,6 +50,9 @@ func TestLoaderLoadOne(t *testing.T) {
 		Factories: blip.Factories{
 			DbConn: dbconn.NewConnFactory(nil, nil),
 		},
+		Plugins: blip.Plugins{TransformMetrics: func(metrics *blip.Metrics) error {
+			return nil
+		}},
 		PlanLoader: plan.NewLoader(nil),
 		RDSLoader:  aws.RDSLoader{ClientFactory: mock.RDSClientFactory{}},
 	}

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -96,6 +96,9 @@ func TestMonitor(t *testing.T) {
 		PlanLoader: pl,
 		DbMaker:    dbMaker,
 		Sinks:      []blip.Sink{sink},
+		TransformMetric: func(metrics *blip.Metrics) error {
+			return nil
+		},
 	})
 
 	if err := mon.Start(); err != nil {


### PR DESCRIPTION
### Note
TransformMetrics is not set in LevelCollector so it cannot be invoked to convert metrics even it is specified by the client. This change is to pass TransformMetrics down to LevelCollector. 

### Testing
Pointed to my local blip change and tested against test metacluster node with TransformMetrics configuration