### PR TITLE
Setup sink client timeout and close idle connections for sfx

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -52,7 +52,9 @@ type httpClientFactory struct {
 }
 
 func (f httpClientFactory) MakeForSink(sinkName, monitorId string, opts, tags map[string]string) (*http.Client, error) {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	if f.cfg.Proxy != "" {
 		proxyFunc := func(req *http.Request) (url *url.URL, err error) {
 			return url.Parse(f.cfg.Proxy)

--- a/server/server.go
+++ b/server/server.go
@@ -52,9 +52,7 @@ type httpClientFactory struct {
 }
 
 func (f httpClientFactory) MakeForSink(sinkName, monitorId string, opts, tags map[string]string) (*http.Client, error) {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-	}
+	client := &http.Client{}
 	if f.cfg.Proxy != "" {
 		proxyFunc := func(req *http.Request) (url *url.URL, err error) {
 			return url.Parse(f.cfg.Proxy)

--- a/sink/signalfx.go
+++ b/sink/signalfx.go
@@ -173,7 +173,13 @@ func (s *SignalFx) Send(ctx context.Context, m *blip.Metrics) error {
 
 	// Send metrics to SFX. The SFX client handles everything; we just pass
 	// it data points.
-	return s.sfxSink.AddDatapoints(ctx, dp[0:n])
+	err := s.sfxSink.AddDatapoints(ctx, dp[0:n])
+	if err != nil {
+		blip.Debug("error sending data points to SignalFx: %s", err)
+		s.sfxSink.Client.CloseIdleConnections()
+	}
+
+	return err
 }
 
 func (s *SignalFx) Name() string {


### PR DESCRIPTION
### Note
Setup http client timeout when creating sink client and close idle connection after a sfx error to fix no datapoints issue in sfx for ~6min.

### Testing
Tested against test cluster nodes