### PR TITLE
Adding DataDog Sink

### DIFF
--- a/blip.go
+++ b/blip.go
@@ -56,7 +56,7 @@ type MetricValue struct {
 	// Boolean values are reported as 0 and 1.
 	Value float64
 
-	// Type is the metric type: COUNTER, COUNTER, and other const.
+	// Type is the metric type: GAUGE, COUNTER, and other const.
 	Type byte
 
 	// Group is the set of name-value pairs that determine the group to which
@@ -65,6 +65,10 @@ type MetricValue struct {
 
 	// Meta is optional key-value pairs that annotate or describe the metric value.
 	Meta map[string]string
+
+	// The frequency that this metric is collected at. Some sinks need this value
+	// to properly process COUNTER type metrics.
+	Frequency int
 }
 
 // Sink sends metrics to an external destination.

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 require github.com/go-test/deep v1.0.8
 
 require (
+	github.com/DataDog/datadog-api-client-go/v2 v2.2.0 // indirect
+	github.com/DataDog/zstd v1.5.0 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.3.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.3 // indirect
@@ -59,5 +61,8 @@ require (
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2 // indirect
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/sapm-proto v0.4.0 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/datadog-api-client-go/v2 v2.2.0 h1:woWe+XBcYt29g1SJs+zbgwYPfyATb+gxeA2pKqUu02Y=
+github.com/DataDog/datadog-api-client-go/v2 v2.2.0/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
+github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
+github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -252,9 +256,12 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -299,6 +306,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -75,7 +75,7 @@ func Exists(domain string) bool {
 // Make makes a metric collector for the domain using a previously registered factory.
 //
 // See types in the blip package for more details.
-func Make(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+func Make(domain string, args blip.CollectorFactoryArgs, frequency int) (blip.Collector, error) {
 	r.Lock()
 	defer r.Unlock()
 	f, ok := r.factory[domain]
@@ -83,7 +83,14 @@ func Make(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error)
 		return nil, fmt.Errorf("invalid domain: %s (no factory registered)", domain)
 
 	}
-	return f.Make(domain, args)
+
+	c, err := f.Make(domain, args)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return blip.NewCollectorFrequencyWrapper(c, frequency), nil
 }
 
 func PrintDomains() string {
@@ -97,7 +104,7 @@ func PrintDomains() string {
 
 	out := ""
 	for _, domain := range domains {
-		mc, _ := Make(domain, blip.CollectorFactoryArgs{Validate: true})
+		mc, _ := Make(domain, blip.CollectorFactoryArgs{Validate: true}, 0)
 		help := mc.Help()
 		out += fmt.Sprintf("%s\n\t%s\n\n",
 			help.Domain, help.Description,

--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -174,6 +174,10 @@ func (e *Engine) Prepare(ctx context.Context, plan blip.Plan, before, after func
 	for levelName, level := range plan.Levels {
 		for domain, _ := range level.Collect {
 
+			// Parse the frequency string so we can pass can associate it
+			// with the collector
+			frequency, _ := time.ParseDuration(level.Freq)
+
 			// Make collector if needed
 			mc, ok := mcNew[domain]
 			if !ok {
@@ -186,6 +190,7 @@ func (e *Engine) Prepare(ctx context.Context, plan blip.Plan, before, after func
 						DB:        e.db,
 						MonitorId: e.monitorId,
 					},
+					int(frequency.Seconds()),
 				)
 				if err != nil {
 					lerr = fmt.Errorf("while making %s collector: %s", domain, err)

--- a/plan/loader.go
+++ b/plan/loader.go
@@ -508,7 +508,7 @@ func ValidatePlans(plans []blip.Plan) error {
 					// a collectory factory error, then the domain is invalid/
 					// doesn't exist
 					var err error
-					mc, err = metrics.Make(domainName, blip.CollectorFactoryArgs{Validate: true})
+					mc, err = metrics.Make(domainName, blip.CollectorFactoryArgs{Validate: true}, 0)
 					if err != nil {
 						errMsgs = append(errMsgs, fmt.Sprintf("invalid plan: %s: at %s/%s: %s",
 							plans[i].Name, levelName, domainName, err))

--- a/sink/datadog.go
+++ b/sink/datadog.go
@@ -1,0 +1,251 @@
+package sink
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/sink/tr"
+	"github.com/cashapp/blip/status"
+)
+
+// SignalFx sends metrics to SignalFx.
+type DataDog struct {
+	monitorId string
+	dim       []string            // monitor.tags (dimensions)
+	tr        tr.DomainTranslator // datadog.metric-translator
+	prefix    string              // datadog.metric-prefix
+	// --
+	metricsApi *datadogV2.MetricsApi
+	apiKeyAuth string
+	appKeyAuth string
+}
+
+func NewDataDog(monitorId string, opts, tags map[string]string, httpClient *http.Client) (*DataDog, error) {
+	c := datadog.NewConfiguration()
+	c.HTTPClient = httpClient
+	metricsApi := datadogV2.NewMetricsApi(datadog.NewAPIClient(c))
+
+	tagList := make([]string, 0, len(tags))
+
+	for k, v := range tags {
+		tagList = append(tagList, fmt.Sprintf("%s:%s", k, v))
+	}
+
+	d := &DataDog{
+		monitorId:  monitorId,
+		dim:        tagList,
+		metricsApi: metricsApi,
+	}
+
+	for k, v := range opts {
+		switch k {
+		case "api-key-auth":
+			d.apiKeyAuth = v
+
+		case "api-key-auth-file":
+			bytes, err := ioutil.ReadFile(v)
+			if err != nil {
+				return nil, err
+			} else {
+				d.apiKeyAuth = string(bytes)
+			}
+
+		case "app-key-auth":
+			d.appKeyAuth = v
+
+		case "app-key-auth-file":
+			bytes, err := ioutil.ReadFile(v)
+			if err != nil {
+				return nil, err
+			} else {
+				d.appKeyAuth = string(bytes)
+			}
+
+		case "metric-translator":
+			tr, err := tr.Make(v)
+			if err != nil {
+				return nil, err
+			}
+			d.tr = tr
+		case "metric-prefix":
+			if v == "" {
+				return nil, fmt.Errorf("datadog sink metric-prefix is empty string; value required when option is specified")
+			}
+			d.prefix = v
+
+		default:
+			return nil, fmt.Errorf("invalid option: %s", k)
+		}
+	}
+
+	if d.apiKeyAuth == "" {
+		return nil, fmt.Errorf("datadog sink required either api-key-auth or api-key-auth-file")
+	}
+
+	if d.appKeyAuth == "" {
+		return nil, fmt.Errorf("datadog sink required either app-key-auth or app-key-auth-file")
+	}
+
+	return d, nil
+}
+
+func (s *DataDog) Send(ctx context.Context, m *blip.Metrics) error {
+	status.Monitor(s.monitorId, s.Name(), "sending metrics")
+
+	// On return, set monitor status for this sink
+	n := 0
+	defer func() {
+		status.Monitor(s.monitorId, s.Name(), "last sent %d metrics at %s", n, time.Now())
+	}()
+
+	// Pre-alloc SFX data points
+	for _, metrics := range m.Values {
+		n += len(metrics)
+	}
+	if n == 0 {
+		return fmt.Errorf("no Blip metrics were collected")
+	}
+	dp := make([]datadogV2.MetricSeries, n)
+	n = 0
+
+	// Convert each Blip metric value to an SFX data point
+	for domain := range m.Values { // each domain
+		metrics := m.Values[domain]
+		var name string
+
+	METRICS:
+		for i := range metrics { // each metric in this domain
+
+			// Set full metric name: translator (if any) else Blip standard,
+			// then prefix (if any)
+			if s.tr == nil {
+				name = domain + "." + metrics[i].Name
+			} else {
+				name = s.tr.Translate(domain, metrics[i].Name)
+			}
+			if s.prefix != "" {
+				name = s.prefix + name
+			}
+
+			// Copy metric meta and groups into tags (dimensions), if any
+			var dim []string
+			if len(metrics[i].Meta) == 0 && len(metrics[i].Group) == 0 {
+				// Optimization: if no meta or group, then reuse pointer to
+				// s.dim which points to the tags--never modify s.dim!
+				dim = s.dim
+			} else {
+				// There are meta or groups (or both), so we MUST COPY tags
+				// from s.dim and the rest into a new map
+				dim = make([]string, 0, len(s.dim)+len(metrics[i].Meta)+len(metrics[i].Group))
+				for _, v := range s.dim { // copy tags (from config)
+					dim = append(dim, v)
+				}
+
+				for k, v := range metrics[i].Meta { // metric meta
+					if k == "ts" { // avoid time series explosion: ts is high cardinality
+						continue
+					}
+					dim = append(dim, fmt.Sprintf("%s:%s", k, v))
+				}
+
+				for k, v := range metrics[i].Group { // metric groups
+					dim = append(dim, fmt.Sprintf("%s:%s", k, v))
+				}
+			}
+
+			var timestamp int64
+
+			// Datadog requires a timestamp when creating a data point
+			if tsStr, ok := metrics[i].Meta["ts"]; !ok {
+				timestamp = m.Begin.Unix()
+			} else {
+				var err error
+				timestamp, err = strconv.ParseInt(tsStr, 10, 64) // ts in milliseconds, string -> int64
+				if err != nil {
+					blip.Debug("invalid timestamp for %s %s: %s: %s", domain, metrics[i].Name, tsStr, err)
+					continue METRICS
+				}
+			}
+
+			var frequency int = metrics[i].Frequency
+
+			// Convert Blip metric type to DataDog metric type
+			switch metrics[i].Type {
+			case blip.COUNTER:
+				dp[n] = datadogV2.MetricSeries{
+					Metric: name,
+					Type:   datadogV2.METRICINTAKETYPE_COUNT.Ptr(),
+					Points: []datadogV2.MetricPoint{
+						{
+							Value:     datadog.PtrFloat64(metrics[i].Value),
+							Timestamp: datadog.PtrInt64(timestamp),
+						},
+					},
+					Tags:     dim,
+					Interval: datadog.PtrInt64(int64(frequency)),
+				}
+			case blip.GAUGE:
+				dp[n] = datadogV2.MetricSeries{
+					Metric: name,
+					Type:   datadogV2.METRICINTAKETYPE_GAUGE.Ptr(),
+					Points: []datadogV2.MetricPoint{
+						{
+							Value:     datadog.PtrFloat64(metrics[i].Value),
+							Timestamp: datadog.PtrInt64(timestamp),
+						},
+					},
+					Tags: dim,
+				}
+			default:
+				// datadog doesn't support this Blip metric type, so skip it
+				continue METRICS // @todo error?
+			}
+
+			n++
+		} // metric
+	} // domain
+
+	// This shouldn't happen: >0 Blip metrics in but =0 DataDog data points out
+	if n == 0 {
+		return fmt.Errorf("no DataDog data points after processing %d Blip metrics", len(m.Values))
+	}
+
+	ddCtx := context.WithValue(
+		ctx,
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {
+				Key: s.apiKeyAuth,
+			},
+			"appKeyAuth": {
+				Key: s.apiKeyAuth,
+			},
+		},
+	)
+
+	payload := datadogV2.MetricPayload{
+		Series: dp,
+	}
+
+	// Send metrics to DataDog. The DataDog client handles everything; we just pass
+	// it data points.
+	_, r, err := s.metricsApi.SubmitMetrics(ddCtx, payload, *datadogV2.NewSubmitMetricsOptionalParameters())
+	if err != nil {
+		blip.Debug("error sending data points to DataDog: %s", err)
+		blip.Debug("error sending data points to DataDog: Http Response - %s", r)
+	}
+
+	return err
+}
+
+func (s *DataDog) Name() string {
+	return "datadog"
+}

--- a/sink/factory.go
+++ b/sink/factory.go
@@ -65,6 +65,7 @@ var noop = noopSink{}
 // --------------------------------------------------------------------------
 
 func init() {
+	Register("datadog", f)
 	Register("chronosphere", f)
 	Register("signalfx", f)
 	Register("log", f)
@@ -144,6 +145,15 @@ func (f *factory) Make(args blip.SinkFactoryArgs) (blip.Sink, error) {
 			return nil, err
 		}
 		retryArgs.Sink, err = NewSignalFx(args.MonitorId, args.Options, args.Tags, httpClient)
+		if err != nil {
+			return nil, err
+		}
+	case "datadog":
+		httpClient, err := f.HTTPClient.MakeForSink("datadog", args.MonitorId, args.Options, args.Tags)
+		if err != nil {
+			return nil, err
+		}
+		retryArgs.Sink, err = NewDataDog(args.MonitorId, args.Options, args.Tags, httpClient)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Adding a sink for DataDog. Updating `MetricValue` to include a `Frequency` field which records the frequency the metric is collected at. This value is need by DataDog's `COUNT` metric type in order to display metrics properly in the UI at various resolutions.

Added `collectorFrequencyWrapper` type to wrap collectors and update the `Frequency` field on the returned `MetricValue`s.