### PR TITLE
Add monitor reloading

### DIFF
--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -356,3 +356,21 @@ func (e *Engine) Collect(ctx context.Context, levelName string) (*blip.Metrics, 
 	atomic.AddUint64(&e.collectFail, 1)
 	return nil, fmt.Errorf("failed to collect %s/%s", e.plan.Name, levelName)
 }
+
+// Stop the engine and cleanup any metrics associated with it.
+func (e *Engine) Stop() {
+	blip.Debug("Stopping engine...")
+	e.planMux.Lock()
+	defer e.planMux.Unlock()
+
+	e.mcMux.Lock()
+	defer e.mcMux.Unlock()
+
+	// Clean up the monitors
+	for _, mc := range e.mcList {
+		if mc.cleanup != nil {
+			blip.Debug("%s cleanup", mc.c.Domain())
+			mc.cleanup()
+		}
+	}
+}

--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -358,6 +358,12 @@ func (e *Engine) Collect(ctx context.Context, levelName string) (*blip.Metrics, 
 }
 
 // Stop the engine and cleanup any metrics associated with it.
+// TODO: There is a possible race condition when this is called. Since
+// Engine.Collect is called as a go-routine, we could have an invocation
+// of the function block waiting for Engine.Stop to runlock planMux,
+// after which Collect would run after cleanup has been called.
+// This could result in a panic, though that should be caught and logged.
+// Since the monitor is stopping anyway this isn't a huge issue.
 func (e *Engine) Stop() {
 	blip.Debug("Stopping engine...")
 	e.planMux.Lock()

--- a/monitor/level_collector.go
+++ b/monitor/level_collector.go
@@ -157,6 +157,9 @@ func (c *lpc) Run(stopChan, doneChan chan struct{}) error {
 				<-c.changePlanDoneChan   // wait for changePlan goroutine
 			default:
 			}
+
+			// Stop the engine and clean up metrics
+			c.engine.Stop()
 			return nil
 		default: // no
 		}


### PR DESCRIPTION
Adding code to reload monitors via the API. Per comments in `loader.go` above `StartMonitors` it _seems_ like this functionality should exist. `loader.Load` supports detecting diffs in monitors but there is no hook from the API to run `Load` then `StartMonitors`.

Added a `Stop` function to `Engine` to facilitate cleaning up metrics when a monitor stops. The level collector has code that runs when a monitor stops but no cleanup on the engine, and the metrics it contains, is ever run. This leaves a heartbeat reader hanging for old monitors using the `repl.lag` metric.

The goal of adding this API endpoint is to facilitate the use of `plugins.LoadMonitors` where the plugin can dynamically update the monitors that need to run. Once the plugin updates the list of monitors it can invoke the reload by hitting the `/monitors/reload` endpoint.