### PR TITLE
Adding Plan Selection to Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -351,6 +351,7 @@ type ConfigMonitor struct {
 	HA        ConfigHighAvailability `yaml:"ha,omitempty"`
 	Heartbeat ConfigHeartbeat        `yaml:"heartbeat,omitempty"`
 	Plans     ConfigPlans            `yaml:"plans,omitempty"`
+	Plan      string                 `yaml:"plan,omitempty"`
 	Sinks     ConfigSinks            `yaml:"sinks,omitempty"`
 	TLS       ConfigTLS              `yaml:"tls,omitempty"`
 

--- a/docs/v1.0/config/config-file.md
+++ b/docs/v1.0/config/config-file.md
@@ -725,7 +725,7 @@ Section [`exporter`](#exporter) is exactly the same in a monitor.
 
 <b>Refer to [Monitor Defaults](#monitor-defaults) for configuring MySQL instances, and remember: [`mysql`](#mysql) variables are top-level in a monitor (omit `mysql:` and include the variables directly).<b>
 
-Monitors have two variables that only appear in monitors: `id` and `meta`.
+Monitors have three variables that only appear in monitors: `id`, `meta`, and `plan`.
 
 ### `id`
 
@@ -771,3 +771,11 @@ This makes monitor metadata useful for advanced or automated configurations beca
 
 Monitor metadata is optional.
 When useful, the Blip documentation will shown to use it.
+
+### `plan`
+{: .var-table }
+|**Type**|string)|
+|**Valid values**|any string|
+|**Default value**||
+
+`plan` selects the plan for the monitor to use if `change` is not configured. Setting `plan` to `""` will select the first plan loaded as the default.

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -463,7 +463,7 @@ func (m *Monitor) startup() error {
 		// Do need retry or error handling because ChangePlan tries forever,
 		// or until called again.
 		status.Monitor(m.monitorId, "monitor", "setting state active")
-		m.lpc.ChangePlan(blip.STATE_ACTIVE, "") // start LPC directly
+		m.lpc.ChangePlan(blip.STATE_ACTIVE, m.cfg.Plan) // start LPC directly
 	}
 
 	return nil


### PR DESCRIPTION
Adding `Plan` to `ConfigMonitor` to allow configuration of the plan by name rather than by load order, which is the default behavior for `Plan = ""`. This is only used if `ConfigMonitor.Plans.Adjust` is not configured.

Updated documentation with some basic info to keep track of this addition.