### PR TITLE
Fix query response time collectors

### DIFF
--- a/docs/v1.0/metrics/domains.md
+++ b/docs/v1.0/metrics/domains.md
@@ -20,12 +20,13 @@ Blip version
 : Blip version domain was added or changed.
 
 MySQL config
-: * _no_ = No configuration required; all metrics available with default MySQL configuration
-* _required_ = Metrics require MySQL configuration as documented
-* _optional_ = Limited metrics unless MySQL configured as documented
+: If MySQL must be explicitly or specially configured to provide the metrics.
 
 Sources
 : MySQL source of metrics.
+
+Derived metrics
+: [Derived metrics](collecting#derived-metrics). Omitted if none.
 
 Group keys
 : [Metric groups](reporting#groups). Omitted if none.
@@ -33,14 +34,11 @@ Group keys
 Meta
 : [Metric meta](reporting#meta). Omitted if none.
 
-Error policy
-: MySQL error codes handled by optional [error policy](../plans/error-policy). Omitted if none.
-
-Derived metrics
-: [Derived metrics](collecting#derived-metrics). Omitted if none.
-
 Options
 : [Domain options](collecting#options). Omitted if none.
+
+Error policy
+: MySQL error codes handled by optional [error policy](../plans/error-policy). Omitted if none.
 
 ---
 
@@ -70,7 +68,7 @@ _InnoDB Metrics_
 |Blip version|v1.0.0|
 |MySQL config|maybe|
 |Sources|`information_schema.innodb_metrics`|
-|Meta|&bull; `subsystem=<SUBSYSTEM column>`|
+|Meta|&bull; `subsystem` = `SUBSYSTEM` column|
 |Options|&bull; `all`|
 
 Metrics from [`INFORMATION_SCHEMA.INNODB_METRICS`](https://dev.mysql.com/doc/refman/en/information-schema-innodb-metrics-table.html).
@@ -81,7 +79,7 @@ Metrics from [`INFORMATION_SCHEMA.INNODB_METRICS`](https://dev.mysql.com/doc/ref
 * `all`<br>
 Default: `no`<br>
 If `yes`, all InnoDB metrics are collect&mdash;the whole table.
-If `no` (the default), only the explicitly listed InnoDB metrics are collected. 
+If `no` (the default), only the explicitly listed InnoDB metrics are collected.
 If `enabled`, only InnoDB metrics enabled by the MySQL configuration are collected (`WHERE status='enabled'` in the table).
 
 <!-------------------------------------------------------------------------->
@@ -94,11 +92,11 @@ _Percona Server Query Response Time_
 |Blip version|v1.0.0|
 |MySQL config|yes|
 |Sources|Percona Server 5.7 [RTD plugin](https://www.percona.com/doc/percona-server/5.7/diagnostics/response_time_distribution.html)|
-|Meta|&bull; `pN=pA`: where `pN` is configured percentile (default: `p999`) and `pA` is actual percentile|
-|Options|&bull; `flush`<br>&bull; `percentiles`<br>&bull; `real-percentiles`|
 |Derived metrics|&bull; `pN` (gauge) for each value in the `percentiles` option|
+|Meta|&bull; `pN=pA`: where `pN` is collected percentile and `pA` is actual percentile|
+|Options|&bull; `flush`<br>&bull; `real-percentiles`|
 
-The `percona.response-time` domain collects query response time percentile metrics from the Percona Server 5.7 [Response Time Distribution plugin](https://www.percona.com/doc/percona-server/5.7/diagnostics/response_time_distribution.html).
+The `percona.response-time` domain collects query response time percentiles from the Percona Server 5.7 [Response Time Distribution plugin](https://www.percona.com/doc/percona-server/5.7/diagnostics/response_time_distribution.html).
 
 This domain is functionally identical to [`query.response-time`](#queryresponse-time); only one option name is different:
 
@@ -118,9 +116,10 @@ _MySQL Query Response Time_
 |Blip version|v1.0.0|
 |MySQL config|yes|
 |Sources|MySQL 8.0 [p_s.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html)|
-|Meta|&bull; `pN=pA`: where `pN` is configured percentile (default: `p999`) and `pA` is actual percentile|
-|Options|&bull; `percentiles`<br>&bull; `real-percentiles`<br>&bull; `truncate-table`|
 |Derived metrics|&bull; `pN` (gauge)<br>|
+|Meta|&bull; `pN=pA`: where `pN` is collected percentile and `pA` is actual percentile|
+|Options|&bull; `real-percentiles`<br>&bull; `truncate-table`|
+|Error policy|&bull; `table-not-exist`|
 
 The `query.response-time` domain collect query response time percentiles.
 By default, it reports the P999 (99.9th percentile) response time in microseconds.
@@ -128,37 +127,40 @@ By default, it reports the P999 (99.9th percentile) response time in microsecond
 {: .note}
 To convert units, use the [TransformMetrics plugin](../integrate#transformmetrics) or write a [custom sink](../sinks/custom).
 
-Multiple percentiles can be collected and reported by setting the `percentiles` option.
-Each percentile in `options` is reported as a separate metric.
-
-#### Options
-{: .no_toc }
-
-* `percentiles`<br>
-Default: 99.9<br>
-Comma-separated list of percentile to report.
-For example, "95,99,99.9" collects and reports three derived metrics: `p95`, `pP99`, and `pP999`.
-Regardless of how percentiles are listed in this option, they are always reported with a "p" prefix and no decimal point.
-For example, option "99.9" is reported as metric "p999".
-* `real-percentiles`<br>
-Default: yes
-If yes (default), reports the real percentile in meta for each percentile in options. 
-MySQL (and Percona Server) use histograms with variable bucket ranges.
-Therefore, the P99 might actually be P98.9 or P99.2.
-Meta key `pN` indicates the configured percentile, and its value `pA` indicates the actual percentile that was used.
-* `truncate-table`<br>
-Default: no
-Truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html) after each collection.
-This reset percentile values so that each collection represents the global query response time during the collection interval rather than during the entire uptime of the MySQL.
-However, truncating the table interferes with other tools reading (or truncating) the table.
-
 #### Derived metrics
 {: .no_toc }
 
 * `pN`<br>
 Type: gauge<br>
-Response time for all queries, reported as a percentile (default: P999) in microseconds.
-The true percentile might be slightly more or less depending on how the histogram buckets are configured.
+Response time percentile to collect where `N` between 1 and 999.
+(The "p" prefix is required.)
+`p95` collects the 95th percentile.
+`p999` collects the 99.9th percentile.
+The response time value is reported in microseconds.
+The true percentile might be slightly greater depending on how the histogram buckets are configured.
+For example, if collecting `p95`, the real percentile might be `p95.8`.
+
+#### Options
+{: .no_toc }
+
+* `real-percentiles`<br>
+Default: yes<br>
+If yes (default), reports the real percentile in meta for each percentile in options.
+MySQL (and Percona Server) use histograms with variable bucket ranges.
+Therefore, the P99 might actually be P98.9 or P99.2.
+Meta key `pN` indicates the configured percentile, and its value `pA` indicates the actual percentile that was used.
+
+* `truncate-table`<br>
+Default: no<br>
+Truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html) after each collection.
+This reset percentile values so that each collection represents the global query response time during the collection interval rather than during the entire uptime of the MySQL.
+However, truncating the table interferes with other tools reading (or truncating) the table.
+
+#### Error Policy
+{: .no_toc }
+
+* `table-not-exist`<br>
+MySQL error 1146: Table 'performance_schema.events_statements_histogram_global' doesn't exist
 
 <!-------------------------------------------------------------------------->
 
@@ -170,10 +172,10 @@ _MySQL Replication_
 |Blip version|v1.0.0|
 |Sources|&#8805;&nbsp;MySQL 8.0.22: `SHOW REPLICA STATUS`<br>&#8804;&nbsp;MySQL 8.0.21: `SHOW SLAVE STATUS`|
 |MySQL config|no|
-|Meta||
 |Derived metrics|&bull; `running` (gauge)|
+|Meta|&bull; `source` = `Source_Host` or `Master_Host`|
 
-The `repl` domain reports a few gauges metrics from the output of `SHOW SLAVE STATUS` (or `SHOW REPLICA STATUS` as of MySQL 8.0.22):
+The `repl` domain reports a few gauges metrics from the output of `SHOW SLAVE STATUS`, or `SHOW REPLICA STATUS` as of MySQL 8.0.22:
 
 |Replica Status Variable|Collected|
 |-----------------------|---------|
@@ -209,8 +211,8 @@ _MySQL Replication Lag_
 |Blip version|v1.0.0|
 |Sources|[Blip Heartbeat](../heartbeat)|
 |MySQL config|yes|
-|Meta|&bull; `source=<src_id column>`|
-|Derived metrics|&bull; `current` (gauge): Current replication lag (milliseconds).<br>|
+|Derived metrics|&bull; `current` (gauge): Current replication lag (milliseconds)<br>|
+|Meta|&bull; `source` = Option `source-id`|
 |Options|&bull; `network-latency`<br>&bull; `repl-check`<br>&bull; `report-no-heartbeat`<br>&bull; `source-id`<br>&bull; `source-role`<br>&bull; `table`<br>&bull; `writer`|
 
 The `repl.lag` collector measures and reports MySQL replication lag from a source using the [Blip heartbeat](../heartbeat).
@@ -237,26 +239,32 @@ Network latency (in milliseconds) between source and replicas.
 The value must be an integer >= 0.
 (Do not suffix with "ms".)
 See [Heartbeat > Accuracy](../heartbeat#accuracy).
+
 * `repl-check`<br>
 MySQL global system variable, like `server_id`.
 (Do not prefix with "@".)
 If the value is zero, replica lag is not collected.
 See [Heartbeat > Repl Check](../heartbeat#repl-check).
+
 * `report-no-heartbeat`<br>
 Default: no<br>
 If yes, no heartbeat from the source is reported as value -1.
 If no, the metric is dropped if no heartbeat from the source.
+
 * `source-id`<br>
 Source ID to report lag from.
 The default (no value) reports lag from the latest (most recent) timestamp.
 See [Heartbeat > Source Following](../heartbeat#source-following).
+
 * `source-role`<br>
 Source role to report lag from.
 If set, the most recent timestamp is used.
 See [Heartbeat > Source Following](../heartbeat#source-following).
+
 * `table`<br>
 Default: `blip.heartbeat`<br>
 Blip [heartbeat table](../heartbeat#table).
+
 * `writer`<br>
 Default: `blip`<br>
 Type of heartbeat writer.
@@ -272,8 +280,8 @@ _Binary Log Storage Size_
 |Blip version|v1.0.0|
 |Sources|`SHOW BINARY LOGS`|
 |MySQL config|no|
+|Derived metrics|&bull; `bytes`: Total size of all binary logs in bytes|
 |Error policy|&bull; `access-denied`<br>&bull; `binlog-not-enabled`|
-|Derived metrics|&bull; `bytes`: Total size of all binary logs in bytes.|
 
 #### Error Policy
 {: .no_toc }
@@ -300,8 +308,8 @@ _Database Storage Sizes_
 {: .var-table}
 |Blip version|v1.0.0|
 |MySQL config|no|
+|Derived metrics|&bull; `bytes`: Database size in bytes|
 |Group keys|`db`|
-|Derived metrics|&bull; `bytes`: Database size in bytes.|
 
 #### Derived metrics
 {: .no_toc }
@@ -319,8 +327,8 @@ _Table Storage Sizes_
 {: .var-table}
 |Blip version|v1.0.0|
 |MySQL config|no|
+|Derived metrics|&bull; `bytes`: Table size in bytes|
 |Group keys|`db`, `tbl`|
-|Derived metrics|&bull; `bytes`: Table size in bytes.|
 
 #### Derived metrics
 {: .no_toc }
@@ -338,6 +346,7 @@ _Global Status Variables_
 {: .var-table}
 |Blip version|v1.0.0|
 |MySQL config|no|
+|Sources|`SHOW GLOBAL STATUS`|
 
 `status.global` collects the primary source of MySQL server metrics: `SHOW GLOBAL STATUS`.
 
@@ -373,6 +382,7 @@ _TLS (SSL) Status and Configuration_
 {: .var-table}
 |Blip version|v1.0.0|
 |MySQL config|no|
+|Sources|Global variables|
 |Derived metrics|&bull; `enabled`: True (1) if have_ssl=YES, else false (0)|
 
 #### Derived metrics
@@ -413,8 +423,8 @@ _MySQL System Variables_
 
 {: .var-table}
 |Blip version|v1.0.0|
-|Sources|`SHOW GLOBAL VARIABLES`, `SELECT @@GLOBAL.<var>`, Performance Schema|
 |MySQL config|no|
+|Sources|`SHOW GLOBAL VARIABLES`, `SELECT @@GLOBAL.<var>`, Performance Schema|
 
 `var.global` collects global MySQL system variables ("sysvars").
 

--- a/docs/v1.0/metrics/quick-ref.md
+++ b/docs/v1.0/metrics/quick-ref.md
@@ -40,6 +40,7 @@ The rest are reserved for future use.
 |ndb|MySQL NDB Cluster||
 |oracle|Oracle enhancements||
 |percona|Percona Server enhancements||
+|[`percona.response-time`](domains#perconaresponse-time)|Percona Server 5.7 Response Time Distribution plugin|v1.0.0|
 |perconca.userstat|[Percona User Statistics](https://www.percona.com/doc/percona-server/8.0/diagnostics/user_stats.html)||
 |percona.userstat.index|Percona `userstat` index statistics (`INFORMATION_SCHEMA.INDEX_STATISTICS`)|
 |percona.userstat.table|Percona `userstat` table statistics||
@@ -47,9 +48,8 @@ The rest are reserved for future use.
 |pfs|Performance Schema `SHOW ENGINE PERFORMANCE_SCHEMA STATUS`||
 |pxc|Percona XtraDB Cluster||
 |query|Query metrics||
-|[`query.global`](domains#queryglobal)|Global query metrics (including response time)|v1.0.0|
-|query.id|Query metrics||
-|repl|MySQL replication `SHOW SLAVE|REPLICA STATUS`|v1.0.0|
+|[`query.response-time`](domains#queryresponse-time)|Global query response time (MySQL 8.0)|v1.0.0|
+|[`repl`](domains#repl)|MySQL replication `SHOW SLAVE|REPLICA STATUS`|v1.0.0|
 |[`repl.lag`](domains#repllag)|MySQL replication lag (including heartbeats)|v1.0.0|
 |rocksdb|RocksDB store engine||
 |size|Storage sizes (in bytes)||

--- a/metrics/percona/qrt.go
+++ b/metrics/percona/qrt.go
@@ -41,10 +41,8 @@ const (
 )
 
 const (
-	OPT_PERCENTILES           = "percentiles"
-	OPT_REAL_PERCENTILES      = "real-percentiles"
-	OPT_FLUSH_QRT             = "flush"
-	default_percentile_option = "999"
+	OPT_REAL_PERCENTILES = "real-percentiles"
+	OPT_FLUSH_QRT        = "flush"
 
 	ERR_UNKNOWN_TABLE = "unknown-table"
 )
@@ -88,12 +86,6 @@ func (c *QRT) Help() blip.CollectorHelp {
 		Domain:      blip_domain,
 		Description: "Collect QRT (Query Response Time) metrics",
 		Options: map[string]blip.CollectorHelpOption{
-			OPT_PERCENTILES: {
-				Name:    OPT_PERCENTILES,
-				Desc:    "Comma-separated list of percentiles formatted as 999, 0.999 or 99.9",
-				Default: default_percentile_option,
-				Values:  map[string]string{},
-			},
 			OPT_REAL_PERCENTILES: {
 				Name:    OPT_REAL_PERCENTILES,
 				Desc:    "If real percentiles are included in meta",
@@ -152,28 +144,20 @@ LEVEL:
 			config.flush = true // default
 		}
 
-		var percentilesStr string
-		if percentilesOption, ok := dom.Options[OPT_PERCENTILES]; ok {
-			percentilesStr = percentilesOption
-		} else {
-			percentilesStr = default_percentile_option
+		// Process list of percentiles metrics into a list of names and values
+		p, err := sqlutil.PercentileMetrics(dom.Metrics)
+		if err != nil {
+			return nil, err
 		}
 
-		var percentiles []percentile
-		percentilesList := strings.Split(strings.TrimSpace(percentilesStr), ",")
-		for _, percentileStr := range percentilesList {
-			p, err := sqlutil.ParsePercentileStr(percentileStr)
-			if err != nil {
-				return nil, err
+		// For each percentile, save a query to fetch its (closest) value
+		config.percentiles = make([]percentile, len(p))
+		for i := range p {
+			config.percentiles[i] = percentile{
+				p:         p[i].Value,
+				formatted: p[i].Name,
 			}
-
-			percentile := percentile{
-				p:         p,
-				formatted: sqlutil.FormatPercentile(p),
-			}
-			percentiles = append(percentiles, percentile)
 		}
-		config.percentiles = percentiles
 
 		// Apply custom error policies, if any
 		config.errPolicy = map[string]*errors.Policy{}

--- a/metrics/query.response-time/response_time_test.go
+++ b/metrics/query.response-time/response_time_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Block, Inc.
+
+package queryresponsetime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cashapp/blip/sqlutil"
+	"github.com/cashapp/blip/test"
+)
+
+func TestCollectP(t *testing.T) {
+	_, db, err := test.Connection("mysql80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	c := NewResponseTime(db)
+
+	// Plan collects p95 and P99. The second should be converted to lowercase p99.
+	plan := test.ReadPlan(t, "../../test/plans/mysql_qrt.yaml")
+	_, err = c.Prepare(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := c.Collect(context.Background(), "kpi")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("collected %d metrics, expected 2: %+v", len(metrics), metrics)
+	}
+
+	// The metric names should match what's listed in the plan (but lowercase)
+	if metrics[0].Name != "p95" {
+		t.Errorf("metrics[0].Name = %s, expected p95", metrics[0].Name)
+	}
+	if metrics[1].Name != "p99" { // lowercase
+		t.Errorf("metrics[1].Name = %s, expected p99", metrics[1].Name)
+	}
+
+	// No way to know what the vaules will be, but we know that
+	// p99 must be >= p95
+	if metrics[1].Value < metrics[0].Value {
+		t.Errorf("p99 = %f < p95 = %f", metrics[1].Value, metrics[0].Value)
+	}
+
+	// By default, meta include real P values: p95 =~ p95.2
+	r, ok := metrics[0].Meta["p95"]
+	if !ok {
+		t.Errorf("metrics[0].Meta doesn't have key p95: %+v", metrics[0].Meta)
+	}
+	f, err := sqlutil.ParsePercentileStr(r)
+	if err != nil {
+		t.Error(err)
+	}
+	if f < 95.0 {
+		t.Errorf("metrics[0] real %s %f < 95.0, expected >= 95.0", r, f)
+	}
+
+	r, ok = metrics[1].Meta["p99"]
+	if !ok {
+		t.Errorf("metrics[0].Meta doesn't have key p99: %+v", metrics[1].Meta)
+	}
+	f, err = sqlutil.ParsePercentileStr(r)
+	if err != nil {
+		t.Error(err)
+	}
+	if f < 99.0 {
+		t.Errorf("metrics[1] real %s %f < 99.0, expected >= 99.0", r, f)
+	}
+}

--- a/sqlutil/percentile.go
+++ b/sqlutil/percentile.go
@@ -12,24 +12,26 @@ import (
 // ParsePercentileStr coverts a string of percentile in different form to the percentile as decimal.
 // There are 3 kind of forms, like P99.9 has form 0.999, form 99.9 or form 999. All should be parsed as 0.999
 func ParsePercentileStr(percentileStr string) (float64, error) {
-	percentileStr = strings.TrimSpace(percentileStr)
-	f, err := strconv.ParseFloat(percentileStr, 64)
+	s := strings.TrimLeft(strings.TrimSpace(percentileStr), "pP")
+	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, fmt.Errorf("percentile value could not be parsed into a number: %s ", percentileStr)
+		return 0, fmt.Errorf("error parsing '%s' ('%s') as float64: %s ", percentileStr, s, err)
 	}
 
 	var percentile float64
 	if f < 1 {
 		// percentile of the form 0.999 (P99.9)
 		percentile = f
-	} else if f >= 1 && f <= 100 {
+	} else if f >= 1 && f < 100 {
 		// percentile of the form 99.9 (P99.9)
 		percentile = f / 100.0
+	} else if f == 100.0 {
+		return 100, nil
 	} else {
 		// percentile of the form 999 (P99.9)
 		// To find the percentage as decimal, we want to convert this number into a float with no significant digits before decimal.
 		// we can do this with: f / (10 ^ (number of digits))
-		percentile = f / math.Pow10(len(percentileStr))
+		percentile = f / math.Pow10(len(s))
 	}
 
 	return percentile, nil
@@ -44,4 +46,27 @@ func FormatPercentile(f float64) string {
 	metaKey = strings.ReplaceAll(metaKey, ".", "")
 	metaKey = "p" + metaKey
 	return metaKey
+}
+
+type P struct {
+	Name  string
+	Value float64
+}
+
+func PercentileMetrics(metrics []string) ([]P, error) {
+	if len(metrics) == 0 {
+		return nil, fmt.Errorf("no percentile metrics specified, expected at least 1 like 'p99'")
+	}
+	p := []P{}
+	for _, s := range metrics {
+		val, err := ParsePercentileStr(s)
+		if err != nil {
+			return nil, err
+		}
+		p = append(p, P{
+			Name:  FormatPercentile(val),
+			Value: val,
+		})
+	}
+	return p, nil
 }

--- a/test/plans/mysql_qrt.yaml
+++ b/test/plans/mysql_qrt.yaml
@@ -1,0 +1,8 @@
+---
+kpi:
+  freq: 5s
+  collect:
+    query.response-time:
+      metrics:
+        - p95
+        - P99


### PR DESCRIPTION
Specify percentiles to collect in metrics, not options.
Instead of:
```yaml
query.response-time:
  options:
    percentiles: "95,99"
```
Now it's consistent with the design of Blip:
```yaml
query.response-time:
  metrics:
    - p95
    - p99
```
