### PR TITLE
Bugfix for `size.database`

### DIFF
--- a/metrics/size.database/database.go
+++ b/metrics/size.database/database.go
@@ -157,7 +157,8 @@ func (c *Database) Collect(ctx context.Context, levelName string) ([]blip.Metric
 		metrics = append(metrics, blip.MetricValue{
 			Name:  "bytes",
 			Type:  blip.GAUGE,
-			Group: map[string]string{"db": ""}, // "" = total
+			Group: map[string]string{"db": ""},
+			Value: total,
 		})
 	}
 


### PR DESCRIPTION
The "total" option, when enabled, sends a metric but the value of the metric is never set.