### PR TITLE
Adding Partitioning to Datadog Sink

### DIFF
--- a/docs/v1.0/sinks/datadog.md
+++ b/docs/v1.0/sinks/datadog.md
@@ -32,4 +32,5 @@ sinks:
     metric-translator: ""
     metric-prefix: ""
     dogstatsd-host: ""
+    api-compress: "true"
 ```

--- a/sink/datadog_test.go
+++ b/sink/datadog_test.go
@@ -1,0 +1,296 @@
+package sink
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/test/mock"
+	"github.com/go-test/deep"
+)
+
+func defaultOps() map[string]string {
+	return map[string]string{
+		"api-key-auth": "testkey",
+		"app-key-auth": "testkey",
+		"api-compress": "true",
+	}
+}
+
+func okHttpClient() *http.Client {
+	return &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+}
+
+func getBlipMetrics(valuesCount int) *blip.Metrics {
+	values := make([]blip.MetricValue, 0, valuesCount)
+
+	for i := 0; i < valuesCount; i++ {
+		values = append(values, blip.MetricValue{
+			Name:  fmt.Sprintf("testmetric%d", i+1),
+			Value: 1.0,
+			Type:  blip.GAUGE,
+		})
+	}
+
+	return &blip.Metrics{
+		Begin:     time.Now().Add(-1 * time.Hour),
+		End:       time.Now(),
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"testdomain": values,
+		},
+	}
+}
+
+func getPayloadSize(r *http.Request, compress bool) (int, error) {
+	bodyReader, err := r.GetBody()
+	if err != nil {
+		return 0, err
+	}
+
+	defer bodyReader.Close()
+	body, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return 0, err
+	}
+
+	if compress {
+		var b bytes.Buffer
+		w := zlib.NewWriter(&b)
+		w.Write(body)
+		w.Close()
+		return len(b.Bytes()), nil
+	}
+
+	return len(body), nil
+}
+
+func TestDatadogSink(t *testing.T) {
+	ddSink, err := NewDatadog("testmonitor", defaultOps(), map[string]string{}, okHttpClient())
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	err = ddSink.Send(context.Background(), getBlipMetrics(10))
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+}
+
+func TestDatadogMetricsPerRequest(t *testing.T) {
+	callCount := 0
+	testPayloadSize := 5000
+	metricCount := 100
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				callCount++
+
+				bodySize, err := getPayloadSize(r, false)
+				if err != nil {
+					return nil, err
+				}
+
+				if bodySize > testPayloadSize {
+					return &http.Response{
+						StatusCode: http.StatusRequestEntityTooLarge,
+					}, nil
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ops["api-compress"] = "false" // Turn off compression so that we get easier calculations for sizing
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	ddSink.maxPayloadSize = testPayloadSize // Set the payload size for testing
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	err = ddSink.Send(context.Background(), getBlipMetrics(metricCount))
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if ddSink.maxMetricsPerRequest == math.MaxInt {
+		t.Error("Expected maxMetricsPerRequest to be adjusted but got MaxInt")
+	}
+
+	if callCount != 4 {
+		t.Errorf("Expected 4 calls but got %d", callCount)
+	}
+}
+
+func TestDatadogMetricsPerRequestWithCompression(t *testing.T) {
+	callCount := 0
+	testPayloadSize := 1500
+	metricCount := 600
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				callCount++
+
+				bodySize, err := getPayloadSize(r, true)
+				if err != nil {
+					return nil, err
+				}
+
+				if bodySize > testPayloadSize {
+					return &http.Response{
+						StatusCode: http.StatusRequestEntityTooLarge,
+					}, nil
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	ddSink.maxPayloadSize = testPayloadSize // Set the payload size for testing
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	err = ddSink.Send(context.Background(), getBlipMetrics(metricCount))
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if ddSink.maxMetricsPerRequest == math.MaxInt {
+		t.Error("Expected maxMetricsPerRequest to be adjusted but got MaxInt")
+	}
+
+	if callCount == 1 {
+		t.Error("Expected more than 1 call but got only 1")
+	}
+}
+
+func TestDatadogMetricsPerRequestMultipleFail(t *testing.T) {
+	callCount := 0
+	testPayloadSize := 5000
+	metricCount := 500
+	trCount := 0
+	var collectedMetrics []string
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				callCount++
+
+				bodySize, err := getPayloadSize(r, false)
+				if err != nil {
+					return nil, err
+				}
+
+				if bodySize > testPayloadSize {
+					return &http.Response{
+						StatusCode: http.StatusRequestEntityTooLarge,
+					}, nil
+				}
+
+				var payload datadogV2.MetricPayload
+				body, _ := r.GetBody()
+				defer body.Close()
+				data, _ := ioutil.ReadAll(body)
+				json.Unmarshal(data, &payload)
+
+				for _, metric := range payload.Series {
+					collectedMetrics = append(collectedMetrics, metric.Metric)
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ops["api-compress"] = "false" // Turn off compression so that we get easier calculations for sizing
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	ddSink.maxPayloadSize = testPayloadSize // Set the payload size for testing
+	ddSink.tr = &mock.Tr{
+		TranslateFunc: func(domain, metric string) string {
+			trCount++
+			// Once we get past a certain number of messages add a long prefix to force
+			// the sink to recalculate the max metrics per request.
+			if trCount > 250 {
+				return fmt.Sprintf("%s.THEQUICKBROWNFOXJUMPEDOVERTHELAZYDOGMAKETHISVERYLONG%s", domain, metric)
+			} else {
+				return fmt.Sprintf("%s.%s", domain, metric)
+			}
+		},
+	}
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	blipMetrics := getBlipMetrics(metricCount)
+	err = ddSink.Send(context.Background(), blipMetrics)
+
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if ddSink.maxMetricsPerRequest == math.MaxInt {
+		t.Error("Expected maxMetricsPerRequest to be adjusted but got MaxInt")
+	}
+
+	if callCount == 1 {
+		t.Error("Expected more than 1 call but only got 1.")
+	}
+
+	expectedMetrics := make([]string, 0, len(blipMetrics.Values))
+	expectedCount := 0
+	for _, metric := range blipMetrics.Values["testdomain"] {
+		expectedCount++
+		if expectedCount > 250 {
+			expectedMetrics = append(expectedMetrics, fmt.Sprintf("testdomain.THEQUICKBROWNFOXJUMPEDOVERTHELAZYDOGMAKETHISVERYLONG%s", metric.Name))
+		} else {
+			expectedMetrics = append(expectedMetrics, fmt.Sprintf("testdomain.%s", metric.Name))
+		}
+
+	}
+
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+}

--- a/test/mock/http.go
+++ b/test/mock/http.go
@@ -1,0 +1,15 @@
+package mock
+
+import "net/http"
+
+// A mock of http.Transport.
+type Transport struct {
+	RoundTripFunc func(*http.Request) (*http.Response, error)
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.RoundTripFunc != nil {
+		return t.RoundTripFunc(req)
+	}
+	return nil, nil
+}

--- a/test/mock/tr.go
+++ b/test/mock/tr.go
@@ -1,0 +1,13 @@
+package mock
+
+type Tr struct {
+	TranslateFunc func(domain, metric string) string
+}
+
+func (tr *Tr) Translate(domain, metric string) string {
+	if tr.TranslateFunc != nil {
+		return tr.TranslateFunc(domain, metric)
+	}
+
+	return metric
+}


### PR DESCRIPTION
Added options for compression and partitioning to the Datadog sink when the API method is used. When receiving an error related to the payload size being too large the sink will attempt to calculate a possible size that will satisfy the size requirements and re-send the metrics. In the event that it exhausts options and cannot send the metrics the attempt will fail.

Added the option to turn on compression for the API, which allows much larger payloads by default.