### PR TITLE
Fixing intermittent panic on metric submission

### DIFF
--- a/sink/datadog.go
+++ b/sink/datadog.go
@@ -367,8 +367,13 @@ func (s *Datadog) sendApi(ddCtx context.Context, dp []datadogV2.MetricSeries) er
 			rangeEnd = len(dp)
 		}
 
+		optParams := *datadogV2.NewSubmitMetricsOptionalParameters()
+		if s.compress {
+			optParams.ContentEncoding = datadogV2.METRICCONTENTENCODING_GZIP.Ptr()
+		}
+
 		if _, r, err := s.metricsApi.SubmitMetrics(ddCtx, *datadogV2.NewMetricPayload(dp[rangeStart:rangeEnd]), *datadogV2.NewSubmitMetricsOptionalParameters()); err != nil {
-			if r.StatusCode == http.StatusRequestEntityTooLarge {
+			if r != nil && r.StatusCode == http.StatusRequestEntityTooLarge {
 				// Is the number of metrics sent already the smallest possible?
 				if localMaxMetricsPerRequest == 1 {
 					return fmt.Errorf("Unable to send metrics: %v", err)


### PR DESCRIPTION
In certain (unknown) cases, submitting metrics via the Datadog API fails with the error `EOF` and a `nil` http response. It appears that while the Datadog API config has a `Compress` field, setting it to `true` does not actually enable compression. It only prevents it from disabling compression:
```golang
if !c.Cfg.Compress {
	// gzip is on by default, so disable it by setting encoding to identity
	localVarRequest.Header.Add("Accept-Encoding", "identity")
}
```

Despite the Datadog client indicating the gzip compression is on by default, an inspection of the code and dumping the request indicates that it is not. Manually setting the content encoding on each request is required to actually enable compression.

In some case the lack of compression caused a failure in the underlying http client which resulted in an `EOF` error. It's unclear what payload size or conditions resulted in this issue, but adding the content encoding resolved the issue.

- Added content encoding of `gzip` when `compress` is set to `true`
- Added a `nil` check on the http response to prevent trying to get the status code from it when it is `nil`