### PR TITLE
Convert ts from ms to seconds in datadog sink

### DIFF
--- a/sink/datadog.go
+++ b/sink/datadog.go
@@ -264,11 +264,12 @@ func (s *Datadog) Send(ctx context.Context, m *blip.Metrics) error {
 				timestamp = m.Begin.Unix()
 			} else {
 				var err error
-				timestamp, err = strconv.ParseInt(tsStr, 10, 64) // ts in milliseconds, string -> int64
+				msTs, err := strconv.ParseInt(tsStr, 10, 64) // ts in milliseconds, string -> int64
 				if err != nil {
 					blip.Debug("invalid timestamp for %s %s: %s: %s", domain, metrics[i].Name, tsStr, err)
 					continue METRICS
 				}
+				timestamp = msTs / 1000 // convert to seconds
 			}
 
 			// Convert Blip metric type to Datadog metric type


### PR DESCRIPTION
Aurora metrics are failing in datadog sink because the timestamps are in `ms` and datadog expects them in `seconds`.

I am converting the the `ts` to seconds to fix the missing metrics.

There's more work to be done in terms of error handling in the sink. I will raise a different PR for other changes. Want to fix the missing metrics first.