### PR TITLE
Add error handling for errors in Datadog API response

### DIFF
--- a/event/list.go
+++ b/event/list.go
@@ -53,3 +53,9 @@ const (
 	STATE_CHANGE_END         = "state-change-end"
 	REPL_SOURCE_CHANGE       = "repl-soruce-change"
 )
+
+// Sink Events
+
+const (
+	SINK_ERROR = "sink-error"
+)

--- a/sink/datadog.go
+++ b/sink/datadog.go
@@ -396,7 +396,8 @@ func (s *Datadog) sendApi(ddCtx context.Context, dp []datadogV2.MetricSeries) er
 
 		if len(apiResponse.Errors) > 0 {
 			// datadog can return a 202 Accepted response code but errors in response payload
-			return fmt.Errorf("error response from Datadog: %s", strings.Join(apiResponse.Errors, ","))
+			// this can be partial success, log it and continue
+			blip.Debug("error(s) returned from datadog: %s", strings.Join(apiResponse.Errors, ","))
 		}
 
 		rangeStart = rangeEnd

--- a/sink/datadog_test.go
+++ b/sink/datadog_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"math"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -313,5 +312,6 @@ func TestDatadogMetricsErrorResponseFromAPI(t *testing.T) {
 
 	err = ddSink.Send(context.Background(), getBlipMetrics(10))
 
-	require.Errorf(t, err, "error response from Datadog: %s", strings.Join(errors, ","))
+	// validation errors should be logged and the sink should continue
+	require.NoError(t, err)
 }

--- a/sink/datadog_test.go
+++ b/sink/datadog_test.go
@@ -294,7 +294,7 @@ func TestDatadogMetricsErrorResponseFromAPI(t *testing.T) {
 	resp := map[string][]string{
 		"errors": errors,
 	}
-	errorsJson, err := json.Marshal(resp)
+	respJSON, err := json.Marshal(resp)
 	require.NoError(t, err)
 
 	httpClient := &http.Client{
@@ -302,7 +302,7 @@ func TestDatadogMetricsErrorResponseFromAPI(t *testing.T) {
 			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusAccepted,
-					Body:       ioutil.NopCloser(bytes.NewReader(errorsJson)),
+					Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
 				}, nil
 			},
 		},


### PR DESCRIPTION
Datadog can return a `202 Accepted` response code but errors in response payload. This PR adds a check for that.

From what it looks like, the endpoint probably also partially accept MetricData which are valid and return errors for invalid ones.

With this, we will at least see in logs what's going on and will be able to fix it quickly. Without this, it was failing silently.