### PR TITLE
Truncation Timeouts

### DIFF
--- a/docs/v1.0/metrics/domains.md
+++ b/docs/v1.0/metrics/domains.md
@@ -126,7 +126,7 @@ _MySQL Query Response Time_
 |Derived metrics|&bull; `pN` (gauge)<br>|
 |Meta|&bull; `pN=pA`: where `pN` is collected percentile and `pA` is actual percentile|
 |Options|&bull; `real-percentiles`<br>&bull; `truncate-table`<br>&bull; `truncate-timeout`|
-|Error policy|&bull; `table-not-exist`<br>&bull; `truncate-failed`|
+|Error policy|&bull; `table-not-exist`<br>&bull; `truncate-timeout`|
 
 The `query.response-time` domain collect query response time percentiles.
 By default, it reports the P999 (99.9th percentile) response time in microseconds.
@@ -164,7 +164,7 @@ This resets percentile values so that each collection represents the global quer
 However, truncating the table interferes with other tools reading (or truncating) the table.
 
 * `truncate-timeout`<br>
-Default: 2s<br>
+Default: 250ms<br>
 The amount of time to wait while attempting to truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html).
 
 #### Error Policy
@@ -173,7 +173,7 @@ The amount of time to wait while attempting to truncate [performance_schema.even
 * `table-not-exist`<br>
 MySQL error 1146: Table 'performance_schema.events_statements_histogram_global' doesn't exist
 
-* `truncate-failed`<br>
+* `truncate-timeout`<br>
 Truncation failures on table 'performance_schema.events_statements_histogram_global'
 
 <!-------------------------------------------------------------------------->
@@ -470,7 +470,7 @@ _Table I/O Wait Metrics_
 |MySQL config|yes|
 |Sources|`performance_schema.table_io_waits_summary_by_table`|
 |Options|&bull; `exclude`<br>&bull; `include`<br>&bull; `truncate`<br>&bull; `truncate-timeout`<br>&bull; `all`|
-|Error policy|&bull; `truncate-failed`|
+|Error policy|&bull; `truncate-timeout`|
 |Group keys|`db`, `tbl`|
 
 Summarized table I/O wait metrics from `performance_schema.table_io_waits_summary_by_table`.
@@ -491,7 +491,7 @@ Default: `yes`<br>
 If the source table should be truncated to reset data after each retrieval.
 
 * `truncate-timeout`<br>
-Default: 2s<br>
+Default: 250ms<br>
 The amount of time to wait while attempting to truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html).
 
 * `all`<br>
@@ -502,5 +502,5 @@ If `no` (the default), only the explicitly listed `performance_schema.table_io_w
 #### Error Policy
 {: .no_toc }
 
-* `truncate-failed`<br>
+* `truncate-timeout`<br>
 Truncation failures on table 'performance_schema.events_statements_histogram_global'

--- a/docs/v1.0/metrics/domains.md
+++ b/docs/v1.0/metrics/domains.md
@@ -125,8 +125,8 @@ _MySQL Query Response Time_
 |Sources|MySQL 8.0 [p_s.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html)|
 |Derived metrics|&bull; `pN` (gauge)<br>|
 |Meta|&bull; `pN=pA`: where `pN` is collected percentile and `pA` is actual percentile|
-|Options|&bull; `real-percentiles`<br>&bull; `truncate-table`|
-|Error policy|&bull; `table-not-exist`|
+|Options|&bull; `real-percentiles`<br>&bull; `truncate-table`<br>&bull; `truncate-timeout`|
+|Error policy|&bull; `table-not-exist`<br>&bull; `truncate-failed`|
 
 The `query.response-time` domain collect query response time percentiles.
 By default, it reports the P999 (99.9th percentile) response time in microseconds.
@@ -158,16 +158,23 @@ Therefore, the P99 might actually be P98.9 or P99.2.
 Meta key `pN` indicates the configured percentile, and its value `pA` indicates the actual percentile that was used.
 
 * `truncate-table`<br>
-Default: no<br>
+Default: yes<br>
 Truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html) after each collection.
-This reset percentile values so that each collection represents the global query response time during the collection interval rather than during the entire uptime of the MySQL.
+This resets percentile values so that each collection represents the global query response time during the collection interval rather than during the entire uptime of the MySQL.
 However, truncating the table interferes with other tools reading (or truncating) the table.
+
+* `truncate-timeout`<br>
+Default: 2s<br>
+The amount of time to wait while attempting to truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html).
 
 #### Error Policy
 {: .no_toc }
 
 * `table-not-exist`<br>
 MySQL error 1146: Table 'performance_schema.events_statements_histogram_global' doesn't exist
+
+* `truncate-failed`<br>
+Truncation failures on table 'performance_schema.events_statements_histogram_global'
 
 <!-------------------------------------------------------------------------->
 
@@ -462,7 +469,8 @@ _Table I/O Wait Metrics_
 |Blip version|v1.0.0|
 |MySQL config|yes|
 |Sources|`performance_schema.table_io_waits_summary_by_table`|
-|Options|&bull; `exclude`<br>&bull; `include`<br>&bull; `truncate`<br>&bull; `all`|
+|Options|&bull; `exclude`<br>&bull; `include`<br>&bull; `truncate`<br>&bull; `truncate-timeout`<br>&bull; `all`|
+|Error policy|&bull; `truncate-failed`|
 |Group keys|`db`, `tbl`|
 
 Summarized table I/O wait metrics from `performance_schema.table_io_waits_summary_by_table`.
@@ -482,7 +490,17 @@ A comma-separated list of database or table names to exclude (ignored if `includ
 Default: `yes`<br>
 If the source table should be truncated to reset data after each retrieval.
 
+* `truncate-timeout`<br>
+Default: 2s<br>
+The amount of time to wait while attempting to truncate [performance_schema.events_statements_histogram_global](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-histogram-summary-tables.html).
+
 * `all`<br>
 Default: `no`<br>
 If `yes`, all `performance_schema.table_io_waits_summary_by_table` metrics are collected&mdash;all columns.
 If `no` (the default), only the explicitly listed `performance_schema.table_io_waits_summary_by_table` metrics are collected.
+
+#### Error Policy
+{: .no_toc }
+
+* `truncate-failed`<br>
+Truncation failures on table 'performance_schema.events_statements_histogram_global'

--- a/errors/truncate_error.go
+++ b/errors/truncate_error.go
@@ -1,0 +1,71 @@
+package errors
+
+import (
+	"github.com/cashapp/blip"
+)
+
+type TruncateErrorPolicy struct {
+	Policy
+	hadTruncateError bool
+}
+
+func NewTruncateErrorPolicy(s string) *TruncateErrorPolicy {
+	p := NewPolicy(s)
+	return &TruncateErrorPolicy{
+		Policy: *p,
+	}
+}
+
+// Handles errors related to truncating tables, specifically those in `performance_schema` where `TRUNCATE` is used to
+// reset the collected performance metrics. This should be called to proces the result of a `TRUNCATE` query even if
+// no error occurrred. It will handle adjusting the collected metric values as necessary based on the success or failure
+// of `TRUNCATE` so that only metrics that were collected from a sample that had a valid collection interval are returned.
+func (p *TruncateErrorPolicy) TruncateError(err error, stop *bool, collectedMetrics []blip.MetricValue) ([]blip.MetricValue, error) {
+	// Track the state of errors from attempting to truncate. We need to determine if
+	// we have recovered from a prior error or not.
+	if err == nil && !p.hadTruncateError {
+		// We are not recovering from an error and truncation was fine, so we should return the collected metrics as-is
+		return collectedMetrics, nil
+	}
+	// We may need to change the resulting metric values depending on if we had an error with truncation or not.
+	// If this is the first instance of a truncation error then the metrics are fine as-is. Once truncation fails
+	// subsequent metrics will have accumulated in the `performance_schema` table over a different interval than
+	// prior samples. In those cases we want to apply our error policy for metrics to the collected values.
+	// We will continue to apply the error processing to metrics until truncation succeeds and the interval of the
+	// collected values returns to the expected value.
+	processMetrics := p.hadTruncateError
+	p.hadTruncateError = (err != nil)
+
+	// Stop trying to collect if error policy retry="stop". This affects
+	// future calls to Collect; don't return yet because we need to check
+	// the metric policy: drop or zero. If zero, we must report one zero val.
+	if p.Retry == POLICY_RETRY_NO {
+		*stop = true
+	}
+
+	// Report
+	var reportedErr error
+	if p.ReportError() {
+		reportedErr = err
+	} else {
+		blip.Debug("error policy=ignore: %v", err)
+	}
+
+	var metrics []blip.MetricValue
+	if processMetrics {
+		if p.Metric == POLICY_METRIC_ZERO {
+			metrics = make([]blip.MetricValue, 0, len(collectedMetrics))
+			for _, existingMetric := range collectedMetrics {
+				metrics = append(metrics, blip.MetricValue{
+					Type:  existingMetric.Type,
+					Name:  existingMetric.Name,
+					Value: 0,
+				})
+			}
+		}
+	} else {
+		metrics = collectedMetrics
+	}
+
+	return metrics, reportedErr
+}

--- a/errors/truncate_error_test.go
+++ b/errors/truncate_error_test.go
@@ -1,0 +1,211 @@
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/errors"
+	"github.com/go-test/deep"
+)
+
+const (
+	TRUNCATE_ERR_STR = "Truncate Error"
+)
+
+func TestTruncateErrorZero(t *testing.T) {
+	t.Parallel()
+	collectedMetrics := []blip.MetricValue{
+		{
+			Name:  "Metric1",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+		{
+			Name:  "Metric2",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+	}
+	zeroMetrics := []blip.MetricValue{
+		{
+			Name:  "Metric1",
+			Type:  blip.COUNTER,
+			Value: 0.0,
+		},
+		{
+			Name:  "Metric2",
+			Type:  blip.COUNTER,
+			Value: 0.0,
+		},
+	}
+
+	testErr := fmt.Errorf(TRUNCATE_ERR_STR)
+	stopValue := false
+	truncatePolicy := errors.NewTruncateErrorPolicy("report,zero,retry")
+
+	returnedMetrics, err := truncatePolicy.TruncateError(nil, &stopValue, collectedMetrics)
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+	if stopValue {
+		t.Errorf("Stop value should be false but it is true")
+	}
+	if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+		t.Error(diff)
+	}
+
+	for i := 0; i < 5; i++ {
+		returnedMetrics, err = truncatePolicy.TruncateError(testErr, &stopValue, collectedMetrics)
+		if stopValue {
+			t.Errorf("Stop value should be false but it is true")
+		}
+
+		if testErr != nil {
+			if err == nil {
+				t.Errorf("Expected an error but got none")
+			} else if err.Error() != TRUNCATE_ERR_STR {
+				t.Errorf("Expected %s but got %v", TRUNCATE_ERR_STR, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		}
+
+		// The first time we get an error we should still have good metrics. Later
+		// iterations should result in metrics with "0" values due to the sampling
+		// interval no longer being correct as a result of truncation errors.
+		if i == 0 {
+			if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+				t.Errorf("Iteration %d: %v", i, diff)
+			}
+		} else if i < 4 {
+			if diff := deep.Equal(zeroMetrics, returnedMetrics); diff != nil {
+				t.Errorf("Iteration %d: %v", i, diff)
+			}
+		} else {
+			// Once we properly recover we should start seeing metrics again
+			if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+				t.Errorf("Iteration %d: %v", i, diff)
+			}
+		}
+
+		// Simulate the truncation failure recovering
+		if i == 2 {
+			testErr = nil
+		}
+	}
+}
+
+func TestTruncateErrorZeroDrop(t *testing.T) {
+	t.Parallel()
+	collectedMetrics := []blip.MetricValue{
+		{
+			Name:  "Metric1",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+		{
+			Name:  "Metric2",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+	}
+
+	testErr := fmt.Errorf(TRUNCATE_ERR_STR)
+	stopValue := false
+	truncatePolicy := errors.NewTruncateErrorPolicy("report,drop,retry")
+
+	returnedMetrics, err := truncatePolicy.TruncateError(nil, &stopValue, collectedMetrics)
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+	if stopValue {
+		t.Errorf("Stop value should be false but it is true")
+	}
+	if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+		t.Error(diff)
+	}
+
+	for i := 0; i < 5; i++ {
+		returnedMetrics, err = truncatePolicy.TruncateError(testErr, &stopValue, collectedMetrics)
+		if stopValue {
+			t.Errorf("Stop value should be false but it is true")
+		}
+
+		if testErr != nil {
+			if err == nil {
+				t.Errorf("Expected an error but got none")
+			} else if err.Error() != TRUNCATE_ERR_STR {
+				t.Errorf("Expected %s but got %v", TRUNCATE_ERR_STR, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		}
+
+		// The first time we get an error we should still have good metrics. Later
+		// iterations should result in metrics being dropped due to the sampling
+		// interval no longer being correct as a result of truncation errors.
+		if i == 0 {
+			if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+				t.Errorf("Iteration %d: %v", i, diff)
+			}
+		} else if i < 4 {
+			if returnedMetrics != nil {
+				t.Errorf("Expected no metrics but got %+v", returnedMetrics)
+			}
+		} else {
+			// Once we properly recover we should start seeing metrics again
+			if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+				t.Errorf("Iteration %d: %v", i, diff)
+			}
+		}
+
+		// Simulate the truncation failure recovering
+		if i == 2 {
+			testErr = nil
+		}
+	}
+}
+
+func TestTruncateErrorZeroStopIgnore(t *testing.T) {
+	t.Parallel()
+	collectedMetrics := []blip.MetricValue{
+		{
+			Name:  "Metric1",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+		{
+			Name:  "Metric2",
+			Type:  blip.COUNTER,
+			Value: 2.0,
+		},
+	}
+
+	testErr := fmt.Errorf(TRUNCATE_ERR_STR)
+	stopValue := false
+	truncatePolicy := errors.NewTruncateErrorPolicy("ignore,drop,stop")
+
+	returnedMetrics, err := truncatePolicy.TruncateError(nil, &stopValue, collectedMetrics)
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+	if stopValue {
+		t.Errorf("Stop value should be false but it is true")
+	}
+	if diff := deep.Equal(collectedMetrics, returnedMetrics); diff != nil {
+		t.Error(diff)
+	}
+
+	returnedMetrics, err = truncatePolicy.TruncateError(testErr, &stopValue, collectedMetrics)
+	if !stopValue {
+		t.Errorf("Stop value should be true but it is false")
+	}
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+}

--- a/metrics/query.response-time/response_time.go
+++ b/metrics/query.response-time/response_time.go
@@ -212,7 +212,9 @@ func (c *ResponseTime) Collect(ctx context.Context, levelName string) ([]blip.Me
 		trCtx, cancelFn := context.WithTimeout(ctx, c.atLevel[levelName].truncateTimeout)
 		defer cancelFn()
 		_, err := c.db.ExecContext(trCtx, TRUNCATE_QUERY)
-		// Process any errors (or lack thereof) with the TruncateErrorPolicy.
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
 		return c.atLevel[levelName].truncateErrPolicy.TruncateError(err, &c.atLevel[levelName].stop, metrics)
 	}
 

--- a/metrics/query.response-time/response_time.go
+++ b/metrics/query.response-time/response_time.go
@@ -23,7 +23,7 @@ const (
 	OPT_TRUNCATE_TIMEOUT = "truncate-timeout"
 
 	ERR_NO_TABLE        = "table-not-exist"
-	ERR_TRUNCATE_FAILED = "truncate-failed"
+	ERR_TRUNCATE_FAILED = "truncate-timeout"
 
 	BASE_QUERY     = "SELECT ROUND(bucket_quantile * 100, 1) AS p, ROUND(bucket_timer_high / 1000000, 3) AS us FROM performance_schema.events_statements_histogram_global"
 	TRUNCATE_QUERY = "TRUNCATE TABLE performance_schema.events_statements_histogram_global"
@@ -35,13 +35,13 @@ type percentile struct {
 }
 
 type qrtConfig struct {
-	percentiles      []percentile
-	setMeta          bool
-	truncate         bool
-	truncateTimeout  time.Duration
-	hadTruncateError bool
-	stop             bool
-	errPolicy        map[string]*errors.Policy
+	percentiles       []percentile
+	setMeta           bool
+	truncate          bool
+	truncateTimeout   time.Duration
+	stop              bool
+	errPolicy         map[string]*errors.Policy
+	truncateErrPolicy *errors.TruncateErrorPolicy
 }
 
 type ResponseTime struct {
@@ -91,7 +91,7 @@ func (c *ResponseTime) Help() blip.CollectorHelp {
 			OPT_TRUNCATE_TIMEOUT: {
 				Name:    OPT_TRUNCATE_TIMEOUT,
 				Desc:    "The amount of time to attempt to truncate the source table before timing out",
-				Default: "2s",
+				Default: "250ms",
 			},
 		},
 		Metrics: []blip.CollectorMetric{
@@ -145,7 +145,7 @@ LEVEL:
 				config.truncateTimeout = duration
 			}
 		} else {
-			config.truncateTimeout = 2 * time.Second // default
+			config.truncateTimeout = 250 * time.Millisecond // default
 		}
 
 		// Process list of percentiles metrics into a list of names and values
@@ -169,8 +169,8 @@ LEVEL:
 		blip.Debug("error policy: %s=%s", ERR_NO_TABLE, config.errPolicy[ERR_NO_TABLE])
 
 		if config.truncate {
-			config.errPolicy[ERR_TRUNCATE_FAILED] = errors.NewPolicy(dom.Errors[ERR_TRUNCATE_FAILED])
-			blip.Debug("error policy: %s=%s", ERR_TRUNCATE_FAILED, config.errPolicy[ERR_TRUNCATE_FAILED])
+			config.truncateErrPolicy = errors.NewTruncateErrorPolicy(dom.Errors[ERR_TRUNCATE_FAILED])
+			blip.Debug("error policy: %s=%s", ERR_TRUNCATE_FAILED, config.truncateErrPolicy.Policy)
 		}
 
 		c.atLevel[level.Name] = config
@@ -212,55 +212,11 @@ func (c *ResponseTime) Collect(ctx context.Context, levelName string) ([]blip.Me
 		trCtx, cancelFn := context.WithTimeout(ctx, c.atLevel[levelName].truncateTimeout)
 		defer cancelFn()
 		_, err := c.db.ExecContext(trCtx, TRUNCATE_QUERY)
-		if err != nil {
-			return c.collectTruncateError(err, levelName, metrics)
-		} else if c.atLevel[levelName].hadTruncateError {
-			// Upon success we can start emitting metrics normally again but we need to
-			// wait for the next collect for the truncate to have taken effect.
-			// Emit whatever metrics would be emitted based on the error policy.
-			metrics, err = c.collectTruncateError(fmt.Errorf("Truncate successful, waiting for next metric collection."), levelName, metrics)
-		}
-		c.atLevel[levelName].hadTruncateError = false
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy.
+		return c.atLevel[levelName].truncateErrPolicy.TruncateError(err, &c.atLevel[levelName].stop, metrics)
 	}
 
 	return metrics, nil
-}
-
-func (c *ResponseTime) collectTruncateError(err error, levelName string, collectedMetrics []blip.MetricValue) ([]blip.MetricValue, error) {
-	var ep *errors.Policy = c.atLevel[levelName].errPolicy[ERR_TRUNCATE_FAILED]
-
-	// Mark as having failed a truncate. This is used to
-	// skip sending metrics until we have a successful truncate.
-	c.atLevel[levelName].hadTruncateError = true
-
-	// Stop trying to collect if error policy retry="stop". This affects
-	// future calls to Collect; don't return yet because we need to check
-	// the metric policy: drop or zero. If zero, we must report one zero val.
-	if ep.Retry == errors.POLICY_RETRY_NO {
-		c.atLevel[levelName].stop = true
-	}
-
-	// Report
-	var reportedErr error
-	if ep.ReportError() {
-		reportedErr = err
-	} else {
-		blip.Debug("error policy=ignore: %v", err)
-	}
-
-	var metrics []blip.MetricValue
-	if ep.Metric == errors.POLICY_METRIC_ZERO {
-		metrics := make([]blip.MetricValue, 0, len(collectedMetrics))
-		for _, existingMetric := range collectedMetrics {
-			metrics = append(metrics, blip.MetricValue{
-				Type:  existingMetric.Type,
-				Name:  existingMetric.Name,
-				Value: 0,
-			})
-		}
-	}
-
-	return metrics, reportedErr
 }
 
 func (c *ResponseTime) collectError(err error, levelName string, metricName string) ([]blip.MetricValue, error) {

--- a/metrics/wait.io.table/table.go
+++ b/metrics/wait.io.table/table.go
@@ -209,9 +209,6 @@ LEVEL:
 			}
 
 			o.lockWaitQuery = fmt.Sprintf(LOCKWAIT_QUERY, int64(lockWaitTimeout))
-		}
-
-		if o.truncate {
 			o.truncateErrPolicy = errors.NewTruncateErrorPolicy(dom.Errors[ERR_TRUNCATE_FAILED])
 			blip.Debug("error policy: %s=%s", ERR_TRUNCATE_FAILED, o.truncateErrPolicy.Policy)
 		}

--- a/metrics/wait.io.table/table.go
+++ b/metrics/wait.io.table/table.go
@@ -266,7 +266,9 @@ func (t *Table) Collect(ctx context.Context, levelName string) ([]blip.MetricVal
 		trCtx, cancelFn := context.WithTimeout(ctx, o.truncateTimeout)
 		defer cancelFn()
 		_, err := t.db.ExecContext(trCtx, TRUNCATE_QUERY)
-		// Process any errors (or lack thereof) with the TruncateErrorPolicy.
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
 		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
 	}
 


### PR DESCRIPTION
Added timeouts on truncation operations for `query.response-time` and `wait.io.table`. In MySQL [locking an instance for backup](https://dev.mysql.com/doc/refman/8.0/en/lock-instance-for-backup.html) will cause `TRUNCATE` to block. This will cause multiple instances of the command to stack up, driving up the thread count on the server. A default timeout of `2s` has been set and is configurable by the user. An error, `truncate-failed` has also been setup to allow users to specify an error handling strategy in the event that `TRUNCATE` fails.