### PR TITLE
Change type of status.max_used_connections to gauge

### DIFF
--- a/metrics/status.global/global.go
+++ b/metrics/status.global/global.go
@@ -222,4 +222,5 @@ var gauge = map[string]bool{
 	"innodb_buffer_pool_pages_total": true,
 	"innodb_row_lock_current_waits":  true,
 	"innodb_os_log_pending_writes":   true,
+	"max_used_connections":           true,
 }


### PR DESCRIPTION
Changing the type of `status.max_used_connections` to gauge.

As we are sending delta for counter metrics now, after a certain period of time most (if not all) data points for this metric will be `0`.

So changing it to gauge instead, we can use `max` as rollup function.