### PR TITLE
Update repl.lag collector to add option for collecting lag using performance schema

### DIFF
--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -141,6 +141,7 @@ LEVEL:
 		c.dropNotAReplica[levelName] = !blip.Bool(dom.Options[OPT_REPORT_NOT_A_REPLICA])
 		c.replCheck = sqlutil.CleanObjectName(dom.Options[OPT_REPL_CHECK]) // @todo sanitize better
 
+		fmt.Printf("Level: %s, Lag Writer: %q", levelName, dom.Options[OPT_WRITER])
 		switch dom.Options[OPT_WRITER] {
 		case LAG_WRITER_PFS:
 			c.lagWriterIn[levelName] = LAG_WRITER_PFS

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -179,7 +179,7 @@ func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue
 		return c.collectPFS(ctx, levelName)
 	}
 
-	panic(fmt.Sprintf("invalid lag writer in Collect %q", c.lagWriterIn[levelName]))
+	panic(fmt.Sprintf("invalid lag writer in Collect %q. All levels: %v", c.lagWriterIn[levelName], c.lagWriterIn))
 }
 
 // //////////////////////////////////////////////////////////////////////////

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -5,6 +5,7 @@ package repllag
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -16,22 +17,35 @@ import (
 const (
 	DOMAIN = "repl.lag"
 
-	OPT_SOURCE_ID            = "source-id"
-	OPT_SOURCE_ROLE          = "source-role"
-	OPT_TABLE                = "table"
-	OPT_WRITER               = "writer"
-	OPT_REPL_CHECK           = "repl-check"
-	OPT_REPORT_NO_HEARTBEAT  = "report-no-heartbeat"
-	OPT_REPORT_NOT_A_REPLICA = "report-not-a-replica"
-	OPT_NETWORK_LATENCY      = "network-latency"
+	OPT_HEARTBEAT_SOURCE_ID   = "heartbeat-source-id"
+	OPT_HEARTBEAT_SOURCE_ROLE = "heartbeat-source-role"
+	OPT_HEARTBEAT_TABLE       = "heartbeat-table"
+	OPT_LAG_SOURCE            = "lag-source"
+	OPT_REPL_CHECK            = "repl-check"
+	OPT_REPORT_NO_HEARTBEAT   = "report-no-heartbeat"
+	OPT_REPORT_NOT_A_REPLICA  = "report-not-a-replica"
+	OPT_NETWORK_LATENCY       = "network-latency"
+
+	LAG_SOURCE_BLIP = "blip"
+	LAG_SOURCE_PFS  = "pfs"
+
+	// MySQL8LagQuery is the query to calculate approximate lag
+	// from replication worker stats in performance schema
+	// This is only available in MySQL 8 (and above) and when performance schema is enabled
+	MySQL8LagQuery = `SELECT TIMESTAMPDIFF(MICROSECOND,
+max(LAST_APPLIED_TRANSACTION_ORIGINAL_COMMIT_TIMESTAMP),
+max(LAST_APPLIED_TRANSACTION_END_APPLY_TIMESTAMP)
+)/1000
+FROM performance_schema.replication_applier_status_by_worker`
 )
 
 type Lag struct {
 	db              *sql.DB
 	lagReader       heartbeat.Reader
-	atLevel         map[string]bool
+	lagSourceIn     map[string]string
 	dropNoHeartbeat map[string]bool
 	dropNotAReplica map[string]bool
+	replCheck       string
 }
 
 var _ blip.Collector = &Lag{}
@@ -39,7 +53,7 @@ var _ blip.Collector = &Lag{}
 func NewLag(db *sql.DB) *Lag {
 	return &Lag{
 		db:              db,
-		atLevel:         map[string]bool{},
+		lagSourceIn:     map[string]string{},
 		dropNoHeartbeat: map[string]bool{},
 		dropNotAReplica: map[string]bool{},
 	}
@@ -54,28 +68,29 @@ func (c *Lag) Help() blip.CollectorHelp {
 		Domain:      DOMAIN,
 		Description: "Replication lag",
 		Options: map[string]blip.CollectorHelpOption{
-			OPT_WRITER: {
-				Name:    OPT_WRITER,
-				Desc:    "Type of heartbeat writer",
-				Default: "blip",
+			OPT_LAG_SOURCE: {
+				Name:    OPT_LAG_SOURCE,
+				Desc:    "How to collect Lag from",
+				Default: "auto",
 				Values: map[string]string{
-					"blip": "Native Blip replication lag",
-					//"pfs":    "MySQL Performance Schema",
+					"auto": "Auto-determine best source",
+					"blip": "Native Blip heartbeat replication lag",
+					"pfs":  "MySQL8 Performance Schema",
 					///"legacy": "Second_Behind_Slave|Replica from SHOW SHOW|REPLICA STATUS",
 				},
 			},
-			OPT_TABLE: {
-				Name:    OPT_TABLE,
+			OPT_HEARTBEAT_TABLE: {
+				Name:    OPT_HEARTBEAT_TABLE,
 				Desc:    "Heartbeat table",
 				Default: blip.DEFAULT_HEARTBEAT_TABLE,
 			},
-			OPT_SOURCE_ID: {
-				Name: OPT_SOURCE_ID,
-				Desc: "Source ID as reported by heartbeat writer; mutually exclusive with " + OPT_SOURCE_ROLE,
+			OPT_HEARTBEAT_SOURCE_ID: {
+				Name: OPT_HEARTBEAT_SOURCE_ID,
+				Desc: "Source ID as reported by heartbeat writer; mutually exclusive with " + OPT_HEARTBEAT_SOURCE_ROLE,
 			},
-			OPT_SOURCE_ROLE: {
-				Name: OPT_SOURCE_ROLE,
-				Desc: "Source role as reported by heartbeat writer; mutually exclusive with " + OPT_SOURCE_ID,
+			OPT_HEARTBEAT_SOURCE_ROLE: {
+				Name: OPT_HEARTBEAT_SOURCE_ROLE,
+				Desc: "Source role as reported by heartbeat writer; mutually exclusive with " + OPT_HEARTBEAT_SOURCE_ID,
 			},
 			OPT_REPL_CHECK: {
 				Name: OPT_REPL_CHECK,
@@ -115,70 +130,122 @@ func (c *Lag) Help() blip.CollectorHelp {
 	}
 }
 
+// Prepare prepares lag collectors for all levels in the plan that contain the "repl.lag" domain
 func (c *Lag) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
 LEVEL:
-	for _, level := range plan.Levels {
+	for levelName, level := range plan.Levels {
 		dom, ok := level.Collect[DOMAIN]
 		if !ok {
 			continue LEVEL // not collected in this level
 		}
+		cleanup, err := c.prepareLevel(levelName, plan.MonitorId, plan.Name, dom.Options)
+		if err != nil {
+			return cleanup, err
+		}
+	}
+	return nil, nil
+}
 
-		table := dom.Options[OPT_TABLE]
+func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	switch c.lagSourceIn[levelName] {
+	case LAG_SOURCE_BLIP:
+		return c.collectBlipHeartBeatLag(ctx, levelName)
+	case LAG_SOURCE_PFS:
+		return c.collectLagFromPFS(ctx, levelName)
+	}
+
+	panic(fmt.Sprintf("invalid source writer in Collect %s", c.lagSourceIn[levelName]))
+}
+
+// //////////////////////////////////////////////////////////////////////////
+// Internal methods
+// //////////////////////////////////////////////////////////////////////////
+
+func (c *Lag) prepareLevel(levelName string, monitorID string, monitorName string, options map[string]string) (func(), error) {
+	c.dropNotAReplica[levelName] = !blip.Bool(options[OPT_REPORT_NOT_A_REPLICA])
+	c.replCheck = sqlutil.CleanObjectName(options[OPT_REPL_CHECK]) // @todo sanitize better
+
+	if writer, ok := options[OPT_LAG_SOURCE]; ok {
+		if len(writer) > 0 && writer != "auto" {
+			switch writer {
+			case LAG_SOURCE_PFS:
+				return nil, c.preparePFS(levelName)
+			case LAG_SOURCE_BLIP:
+				return c.prepareBlipHeartbeatLag(levelName, monitorID, monitorName, options)
+			default:
+				return nil, fmt.Errorf("invalid lag source: %s; valid values: auto, pfs, blip", writer)
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Auto source (default)
+	// -------------------------------------------------------------------------
+	var err error
+	if err = c.preparePFS(levelName); err == nil {
+		return nil, nil
+	}
+
+	if cleanup, err := c.prepareBlipHeartbeatLag(levelName, monitorID, monitorName, options); err == nil {
+		return cleanup, nil
+	}
+
+	return nil, fmt.Errorf("auto lag source failed, last error: %s", err)
+}
+
+func (c *Lag) prepareBlipHeartbeatLag(levelName string, monitorID string, planName string, options map[string]string) (func(), error) {
+	if c.lagReader == nil {
+		c.dropNoHeartbeat[levelName] = !blip.Bool(options[OPT_REPORT_NO_HEARTBEAT])
+
+		table := options[OPT_HEARTBEAT_TABLE]
 		if table == "" {
 			table = blip.DEFAULT_HEARTBEAT_TABLE
 		}
-
-		c.dropNoHeartbeat[level.Name] = !blip.Bool(dom.Options[OPT_REPORT_NO_HEARTBEAT])
-		c.dropNotAReplica[level.Name] = !blip.Bool(dom.Options[OPT_REPORT_NOT_A_REPLICA])
-
 		netLatency := 50 * time.Millisecond
-		if s, ok := dom.Options[OPT_NETWORK_LATENCY]; ok {
+		if s, ok := options[OPT_NETWORK_LATENCY]; ok {
 			n, err := strconv.Atoi(s)
 			if err != nil {
-				blip.Debug("%s: invalid network-latency: %s: %s (ignoring; using default 50 ms)", plan.MonitorId, s, err)
+				blip.Debug("%s: invalid network-latency: %s: %s (ignoring; using default 50 ms)", monitorID, s, err)
 			} else {
 				netLatency = time.Duration(n) * time.Millisecond
 			}
 		}
-
-		switch dom.Options[OPT_WRITER] {
-		case "", "blip": // "" == default == blip
-			if c.lagReader == nil {
-				// Only 1 reader per plan
-				c.lagReader = heartbeat.NewBlipReader(heartbeat.BlipReaderArgs{
-					MonitorId:  plan.MonitorId,
-					DB:         c.db,
-					Table:      table,
-					SourceId:   dom.Options[OPT_SOURCE_ID],
-					SourceRole: dom.Options[OPT_SOURCE_ROLE],
-					ReplCheck:  sqlutil.CleanObjectName(dom.Options[OPT_REPL_CHECK]), // @todo sanitize better
-					Waiter: heartbeat.SlowFastWaiter{
-						MonitorId:      plan.MonitorId,
-						NetworkLatency: netLatency,
-					},
-				})
-				go c.lagReader.Start()
-				blip.Debug("%s: started reader: %s/%s (network latency: %s)", plan.MonitorId, plan.Name, level.Name, netLatency)
-			}
-			c.atLevel[level.Name] = true
-		}
+		// Only 1 reader per plan
+		c.lagReader = heartbeat.NewBlipReader(heartbeat.BlipReaderArgs{
+			MonitorId:  monitorID,
+			DB:         c.db,
+			Table:      table,
+			SourceId:   options[OPT_HEARTBEAT_SOURCE_ID],
+			SourceRole: options[OPT_HEARTBEAT_SOURCE_ROLE],
+			ReplCheck:  c.replCheck,
+			Waiter: heartbeat.SlowFastWaiter{
+				MonitorId:      monitorID,
+				NetworkLatency: netLatency,
+			},
+		})
+		go c.lagReader.Start()
+		blip.Debug("%s: started reader: %s/%s (network latency: %s)", monitorID, planName, levelName, netLatency)
 	}
-
+	c.lagSourceIn[levelName] = LAG_SOURCE_BLIP
 	var cleanup func()
 	if c.lagReader != nil {
 		cleanup = func() {
-			blip.Debug("%s: stopping reader", plan.MonitorId)
+			blip.Debug("%s: stopping reader", monitorID)
 			c.lagReader.Stop()
 		}
 	}
-
 	return cleanup, nil
 }
 
-func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
-	if !c.atLevel[levelName] {
-		return nil, nil
-	}
+func (c *Lag) preparePFS(levelName string) error {
+	c.lagSourceIn[levelName] = LAG_SOURCE_PFS
+
+	// Try collecting, discard metrics
+	_, err := c.collectLagFromPFS(context.TODO(), levelName)
+	return err
+}
+
+func (c *Lag) collectBlipHeartBeatLag(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
 	lag, err := c.lagReader.Lag(ctx)
 	if err != nil {
 		return nil, err
@@ -195,6 +262,61 @@ func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue
 		Type:  blip.GAUGE,
 		Value: float64(lag.Milliseconds),
 		Meta:  map[string]string{"source": lag.SourceId},
+	}
+	return []blip.MetricValue{m}, nil
+}
+
+func (c *Lag) collectLagFromPFS(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	// if isReplCheck is supplied, check if it's a replica
+	defaultLag := func() ([]blip.MetricValue, error) {
+		if c.dropNotAReplica[levelName] {
+			return nil, nil
+		} else {
+			// send -1 for lag
+			m := blip.MetricValue{
+				Name:  "current",
+				Type:  blip.GAUGE,
+				Value: float64(-1),
+			}
+			return []blip.MetricValue{m}, nil
+		}
+	}
+	isRepl := 1
+	if c.replCheck != "" {
+		query := "SELECT @@" + c.replCheck
+		if err := c.db.QueryRow(query).Scan(&isRepl); err != nil {
+			return nil, fmt.Errorf("checking if instance is replica failed, please check value of %s. Err: %s", OPT_REPL_CHECK, err.Error())
+		}
+	}
+
+	if isRepl == 0 {
+		return defaultLag()
+	}
+	// instance is a replica or replCheck is not set
+
+	var lagValue sql.NullString
+	if err := c.db.QueryRow(MySQL8LagQuery).Scan(&lagValue); err != nil {
+		return nil, fmt.Errorf("could not check replication lag, check that this is a MySQL 8.0 replica, and that performance_schema is enabled. Err: %s", err.Error())
+	}
+	if !lagValue.Valid {
+		// it is a MySQL 8 instance and performance schema is enabled, otherwise the query would have returned error
+		// if replCheck is empty, we can assume based on the query that it's a replica and return nil or -1
+		if c.replCheck == "" {
+			return defaultLag()
+		} else {
+			// it's a replica, so lagValue should be valid, raise error
+			return nil, fmt.Errorf("instance is a MySQL 8 replica and performance schema is enabled, still could not calculate lag, please check manually. Lag: %q", lagValue.String)
+		}
+	}
+
+	f, ok := sqlutil.Float64(lagValue.String)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert replica lag from performance schema into float. Lag: %s", lagValue.String)
+	}
+	m := blip.MetricValue{
+		Name:  "current",
+		Type:  blip.GAUGE,
+		Value: f,
 	}
 	return []blip.MetricValue{m}, nil
 }

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -223,7 +223,7 @@ LEVEL:
 		c.lagWriterIn[levelName] = writer // collect at this level
 
 		c.dropNotAReplica[levelName] = !blip.Bool(dom.Options[OPT_REPORT_NOT_A_REPLICA])
-		c.renameDefaultReplicationChannel[levelName] = !blip.Bool(dom.Options[OPT_RENAME_DEFAULT_REPLICATION_CHANNEL])
+		c.renameDefaultReplicationChannel[levelName] = blip.Bool(dom.Options[OPT_RENAME_DEFAULT_REPLICATION_CHANNEL])
 		c.replCheck = sqlutil.CleanObjectName(dom.Options[OPT_REPL_CHECK]) // @todo sanitize better
 	}
 

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cashapp/blip"
@@ -132,6 +133,11 @@ func (c *Lag) Help() blip.CollectorHelp {
 
 // Prepare prepares lag collectors for all levels in the plan that contain the "repl.lag" domain
 func (c *Lag) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	var once sync.Once
+	once.Do(func() {
+		// print the plan
+		fmt.Printf("Plan from repl.lag: %v", plan)
+	})
 LEVEL:
 	for levelName, level := range plan.Levels {
 		dom, ok := level.Collect[DOMAIN]

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -160,12 +160,14 @@ LEVEL:
 		// -------------------------------------------------------------------------
 		// Auto source (default)
 		// -------------------------------------------------------------------------
+		// Try PFS first
 		var err error
 		if _, err = c.collectPFS(ctx, levelName); err == nil {
 			c.lagSourceIn[levelName] = LAG_SOURCE_PFS
 			return nil, nil
 		}
 
+		// then Blip HeartBeat
 		cleanup, err := c.prepareBlip(levelName, plan.MonitorId, plan.Name, dom.Options)
 		if err == nil {
 			return cleanup, nil

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -154,7 +154,7 @@ func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue
 		return c.collectLagFromPFS(ctx, levelName)
 	}
 
-	panic(fmt.Sprintf("invalid source writer in Collect %s", c.lagSourceIn[levelName]))
+	panic(fmt.Sprintf("invalid lag source in Collect %s", c.lagSourceIn[levelName]))
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -165,15 +165,15 @@ func (c *Lag) prepareLevel(levelName string, monitorID string, monitorName strin
 	c.dropNotAReplica[levelName] = !blip.Bool(options[OPT_REPORT_NOT_A_REPLICA])
 	c.replCheck = sqlutil.CleanObjectName(options[OPT_REPL_CHECK]) // @todo sanitize better
 
-	if writer, ok := options[OPT_LAG_SOURCE]; ok {
-		if len(writer) > 0 && writer != "auto" {
-			switch writer {
+	if source, ok := options[OPT_LAG_SOURCE]; ok {
+		if len(source) > 0 && source != "auto" {
+			switch source {
 			case LAG_SOURCE_PFS:
 				return nil, c.preparePFS(levelName)
 			case LAG_SOURCE_BLIP:
 				return c.prepareBlipHeartbeatLag(levelName, monitorID, monitorName, options)
 			default:
-				return nil, fmt.Errorf("invalid lag source: %s; valid values: auto, pfs, blip", writer)
+				return nil, fmt.Errorf("invalid lag source: %s; valid values: auto, pfs, blip", source)
 			}
 		}
 	}
@@ -300,7 +300,7 @@ func (c *Lag) collectLagFromPFS(ctx context.Context, levelName string) ([]blip.M
 	}
 	if !lagValue.Valid {
 		// it is a MySQL 8 instance and performance schema is enabled, otherwise the query would have returned error
-		// if replCheck is empty, we can assume based on the query that it's a replica and return nil or -1
+		// if replCheck is empty, we can assume based on the query that it's not a replica and return nil or -1
 		if c.replCheck == "" {
 			return defaultLag()
 		} else {

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -65,6 +65,8 @@ type Lag struct {
 	dropNotAReplica                 map[string]bool
 	renameDefaultReplicationChannel map[string]bool
 	replCheck                       string
+	pfsLagLastQueued                map[string]string
+	pfsLagLastProc                  map[string]string
 }
 
 var _ blip.Collector = &Lag{}
@@ -76,6 +78,8 @@ func NewLag(db *sql.DB) *Lag {
 		dropNoHeartbeat:                 map[string]bool{},
 		dropNotAReplica:                 map[string]bool{},
 		renameDefaultReplicationChannel: map[string]bool{},
+		pfsLagLastQueued:                make(map[string]string),
+		pfsLagLastProc:                  make(map[string]string),
 	}
 }
 

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -179,7 +179,7 @@ func (c *Lag) Collect(ctx context.Context, levelName string) ([]blip.MetricValue
 		return c.collectPFS(ctx, levelName)
 	}
 
-	panic(fmt.Sprintf("invalid lag writer in Collect %q. All levels: %v", c.lagWriterIn[levelName], c.lagWriterIn))
+	panic(fmt.Sprintf("invalid lag writer in Collect %q in level %q. All levels: %v", c.lagWriterIn[levelName], levelName, c.lagWriterIn))
 }
 
 // //////////////////////////////////////////////////////////////////////////

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -291,7 +291,7 @@ func (c *Lag) collectPFS(ctx context.Context, levelName string) ([]blip.MetricVa
 		if c.replCheck == "" {
 			return defaultLag, nil
 		} else {
-			// it's a replica, so lagValue should be valid, raise error
+			// it's a replica, so lagValue should be valid, but it's not so raise error
 			return nil, fmt.Errorf("cannot determine replica lag because performance_schema.replication_applier_status_by_worker returned an invalid value: %q (expected a positive integer value)", lagValue.String)
 		}
 	}

--- a/metrics/repl.lag/lag.go
+++ b/metrics/repl.lag/lag.go
@@ -141,7 +141,7 @@ LEVEL:
 		c.dropNotAReplica[levelName] = !blip.Bool(dom.Options[OPT_REPORT_NOT_A_REPLICA])
 		c.replCheck = sqlutil.CleanObjectName(dom.Options[OPT_REPL_CHECK]) // @todo sanitize better
 
-		fmt.Printf("Level: %s, Lag Writer: %q", levelName, dom.Options[OPT_WRITER])
+		fmt.Printf("Level: %s, Lag Writer: %q, levelCollect: %v", levelName, dom.Options[OPT_WRITER], dom)
 		switch dom.Options[OPT_WRITER] {
 		case LAG_WRITER_PFS:
 			c.lagWriterIn[levelName] = LAG_WRITER_PFS

--- a/metrics/repl.lag/lag_test.go
+++ b/metrics/repl.lag/lag_test.go
@@ -1,0 +1,136 @@
+// Copyright 2022, Block, Inc.
+
+package repllag
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/cashapp/blip/test"
+)
+
+func TestPrepareForSingleLevelAndNoSourceOnMySQL57(t *testing.T) {
+	// default source on MySQL 5.7 should be `blip`
+	_, db, err := test.Connection("mysql57")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	c := NewLag(db)
+
+	defaultPlan := test.ReadPlan(t, "")
+	_, err = c.Prepare(context.Background(), defaultPlan)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "blip", c.lagSourceIn["kpi"])
+}
+
+func TestPrepareForSingleLevelAndNoSourceOnMySQL80(t *testing.T) {
+	// default source on MySQL 8.0 should be `pfs`
+	_, db, err := test.Connection("mysql80")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	c := NewLag(db)
+
+	defaultPlan := test.ReadPlan(t, "")
+	_, err = c.Prepare(context.Background(), defaultPlan)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "pfs", c.lagSourceIn["kpi"])
+}
+
+func TestPrepareWithInvalidSource(t *testing.T) {
+	_, db, err := test.Connection("mysql80")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	c := NewLag(db)
+
+	plan := test.ReadPlan(t, "")
+	plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_LAG_SOURCE] = "invalid-lag-source"
+	_, err = c.Prepare(context.Background(), plan)
+	assert.Error(t, err)
+}
+
+func TestCollectWithNoSource(t *testing.T) {
+	// defaults to pfs
+	_, db, err := test.Connection("mysql80")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	c := NewLag(db)
+
+	plan := test.ReadPlan(t, "")
+	plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NOT_A_REPLICA] = "yes"
+	plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPL_CHECK] = "read_only"
+	_, err = c.Prepare(context.Background(), plan)
+	if err != nil {
+		t.Error(err)
+	}
+	metrics, _ := c.Collect(context.TODO(), "kpi")
+	assert.Equal(t, 1, len(metrics))
+
+	assert.Equal(t, metrics[0].Name, "current")
+	assert.Equal(t, metrics[0].Value, float64(-1))
+}
+
+func TestCollectWithAllSources(t *testing.T) {
+	// defaults to pfs
+	_, db, err := test.Connection("mysql80")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	srcs := [3]string{"auto", "pfs", "blip"}
+
+	for _, src := range srcs {
+		c := NewLag(db)
+		plan := test.ReadPlan(t, "")
+		plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NOT_A_REPLICA] = "yes"
+		if src == "blip" {
+			plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NO_HEARTBEAT] = "yes"
+		}
+		_, err = c.Prepare(context.Background(), plan)
+		if err != nil {
+			t.Error(err)
+		}
+		metrics, _ := c.Collect(context.TODO(), "kpi")
+		assert.Equal(t, 1, len(metrics))
+		assert.Equal(t, metrics[0].Name, "current")
+		assert.Equal(t, metrics[0].Value, float64(-1))
+	}
+}

--- a/metrics/repl.lag/lag_test.go
+++ b/metrics/repl.lag/lag_test.go
@@ -30,7 +30,7 @@ func TestPrepareForSingleLevelAndNoSourceOnMySQL57(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, "blip", c.lagSourceIn["kpi"])
+	assert.Equal(t, "blip", c.lagWriterIn["kpi"])
 }
 
 func TestPrepareForSingleLevelAndNoSourceOnMySQL80(t *testing.T) {
@@ -53,7 +53,7 @@ func TestPrepareForSingleLevelAndNoSourceOnMySQL80(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, "pfs", c.lagSourceIn["kpi"])
+	assert.Equal(t, "pfs", c.lagWriterIn["kpi"])
 }
 
 func TestPrepareWithInvalidSource(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPrepareWithInvalidSource(t *testing.T) {
 	c := NewLag(db)
 
 	plan := test.ReadPlan(t, "")
-	plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_LAG_SOURCE] = "invalid-lag-source"
+	plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_WRITER] = "invalid-lag-source"
 	_, err = c.Prepare(context.Background(), plan)
 	assert.Error(t, err)
 }

--- a/metrics/repl.lag/lag_test.go
+++ b/metrics/repl.lag/lag_test.go
@@ -129,7 +129,5 @@ func TestCollectWithAllSources(t *testing.T) {
 		}
 		metrics, _ := c.Collect(context.TODO(), "kpi")
 		assert.Equal(t, 0, len(metrics))
-		//assert.Equal(t, metrics[0].Name, "current")
-		//assert.Equal(t, metrics[0].Value, float64(-1))
 	}
 }

--- a/metrics/repl.lag/lag_test.go
+++ b/metrics/repl.lag/lag_test.go
@@ -96,11 +96,9 @@ func TestCollectWithNoSource(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	metrics, _ := c.Collect(context.TODO(), "kpi")
+	metrics, err := c.Collect(context.TODO(), "kpi")
 	assert.Equal(t, 1, len(metrics))
-
-	assert.Equal(t, metrics[0].Name, "current")
-	assert.Equal(t, metrics[0].Value, float64(-1))
+	assert.NoError(t, err)
 }
 
 func TestCollectWithAllSources(t *testing.T) {
@@ -120,17 +118,18 @@ func TestCollectWithAllSources(t *testing.T) {
 	for _, src := range srcs {
 		c := NewLag(db)
 		plan := test.ReadPlan(t, "")
-		plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NOT_A_REPLICA] = "yes"
+		plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NOT_A_REPLICA] = "no"
 		if src == "blip" {
-			plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NO_HEARTBEAT] = "yes"
+			plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_REPORT_NO_HEARTBEAT] = "no"
 		}
+		plan.Levels["kpi"].Collect[DOMAIN].Options[OPT_WRITER] = src
 		_, err = c.Prepare(context.Background(), plan)
 		if err != nil {
 			t.Error(err)
 		}
 		metrics, _ := c.Collect(context.TODO(), "kpi")
-		assert.Equal(t, 1, len(metrics))
-		assert.Equal(t, metrics[0].Name, "current")
-		assert.Equal(t, metrics[0].Value, float64(-1))
+		assert.Equal(t, 0, len(metrics))
+		//assert.Equal(t, metrics[0].Name, "current")
+		//assert.Equal(t, metrics[0].Value, float64(-1))
 	}
 }

--- a/metrics/repl.lag/pfs.go
+++ b/metrics/repl.lag/pfs.go
@@ -115,8 +115,8 @@ func (c *Lag) collectPFS(ctx context.Context, levelName string) ([]blip.MetricVa
 	// collect lag per channel
 	for channel, workers := range channels {
 		// MySQL use "" as the default channel name, blip provides a way to rename it to 'default' if the user wants
-		if channel == "" && c.renameDefaultReplicationChannel[levelName] {
-			channel = defaultChannelName
+		if channel == "" && c.defaultChannelNameOverrides[levelName] != "" {
+			channel = c.defaultChannelNameOverrides[levelName]
 		}
 		lag := lagFor(workers, c.pfsLagLastQueued, c.pfsLagLastProc)
 		lagMetrics = append(lagMetrics, blip.MetricValue{

--- a/metrics/repl.lag/pfs.go
+++ b/metrics/repl.lag/pfs.go
@@ -1,0 +1,269 @@
+// Copyright 2024 Block, Inc.
+
+package repllag
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/cashapp/blip"
+)
+
+// This file calculates Replica Lag from Performance Schema
+// See lag() for how this is used.
+const mySQL8LagQuery = `SELECT
+  r.CHANNEL_NAME,
+  r.LAST_QUEUED_TRANSACTION,
+  r.SERVICE_STATE 'io_thd',
+  c.SERVICE_STATE 'sql_thd',
+  c.LAST_PROCESSED_TRANSACTION,
+  w.WORKER_ID,
+  w.LAST_APPLIED_TRANSACTION,
+  UNIX_TIMESTAMP(NOW(6)) 'now',
+  UNIX_TIMESTAMP(LAST_APPLIED_TRANSACTION_IMMEDIATE_COMMIT_TIMESTAMP) 'last_applied_ts',
+  COALESCE(TIMESTAMPDIFF(MICROSECOND, LAST_APPLIED_TRANSACTION_IMMEDIATE_COMMIT_TIMESTAMP, LAST_APPLIED_TRANSACTION_END_APPLY_TIMESTAMP), 0) 'last_applied_lag',
+  UNIX_TIMESTAMP(APPLYING_TRANSACTION_IMMEDIATE_COMMIT_TIMESTAMP) 'applying_ts'
+FROM
+  performance_schema.replication_connection_status r
+  JOIN performance_schema.replication_applier_status_by_coordinator c USING (channel_name)
+  JOIN performance_schema.replication_applier_status_by_worker w USING (channel_name);
+`
+
+// worker is one row from the query above. All timestamps are microseconds from MySQL.
+type worker struct {
+	channel        string // key
+	lastQueuedTrx  string
+	ioThd          string
+	sqlThd         string
+	lastProcTrx    string
+	id             int
+	lastAppliedTrx string
+	now            float64 // from MySQL, microseconds
+	lastAppliedTs  float64
+	lastAppliedLag float64
+	applyingTs     float64
+}
+
+// lag is computed from a []worker per channel.
+type lag struct {
+	applying    uint    // how many workers are applying
+	observed    string  // O_ const (just for print, human observation)
+	current     float64 // microseconds
+	trxId       string  // max applied trx ID (just for print, human observation)
+	backlog     int     // last queued - last applied
+	workerUsage float64 // applying workers / total workers * 100
+}
+
+const (
+	O_APPLYING = "a" // at least 1 worker applying
+	O_RECEIVED = "r" // no workers applying but more trx queued
+	O_STOPPED  = "x" // IO or SQL thread != "ON"
+	O_IDLE     = " " // none of the above == true zero lag
+)
+
+func (c *Lag) collectPFSv2(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	var defaultLag []blip.MetricValue
+	if c.dropNotAReplica[levelName] {
+		defaultLag = nil
+	} else {
+		// send -1 for lag
+		m := blip.MetricValue{
+			Name:  "current",
+			Type:  blip.GAUGE,
+			Value: float64(-1),
+		}
+		defaultLag = []blip.MetricValue{m}
+	}
+
+	// if isReplCheck is supplied, check if it's a replica
+	isRepl := 1
+	if c.replCheck != "" {
+		query := "SELECT @@" + c.replCheck
+		if err := c.db.QueryRowContext(ctx, query).Scan(&isRepl); err != nil {
+			return nil, fmt.Errorf("checking if instance is replica failed, please check value of %s. Err: %s", OPT_REPL_CHECK, err.Error())
+		}
+	}
+
+	if isRepl == 0 {
+		return defaultLag, nil
+	}
+
+	lastQueued := map[string]string{} // by replica/to relay log
+	lastProc := map[string]string{}   // by coordinator/to workers
+
+	rows, err := c.db.QueryContext(context.Background(), mySQL8LagQuery)
+	if err != nil {
+		return nil, fmt.Errorf("could not check replication lag, check that the host is a MySQL 8.0 replica, and that performance_schema is enabled. Err: %s", err.Error())
+	}
+
+	// Group workers by channel name
+	channels := map[string][]worker{}
+	for rows.Next() {
+		w := worker{}
+		if err := rows.Scan(&w.channel, &w.lastQueuedTrx, &w.ioThd, &w.sqlThd, &w.lastProcTrx, &w.id, &w.lastAppliedTrx, &w.now, &w.lastAppliedTs, &w.lastAppliedLag, &w.applyingTs); err != nil {
+			log.Fatal(err)
+		}
+		if _, ok := channels[w.channel]; !ok { // new channel
+			channels[w.channel] = []worker{}
+		}
+		channels[w.channel] = append(channels[w.channel], w)
+	}
+	rows.Close()
+
+	var lagMetrics []blip.MetricValue
+	var backlog, workerUsage float64
+
+	// collect lag per channel
+	for channel, workers := range channels {
+		lag := lagFor(workers, lastQueued, lastProc)
+		lagMetrics = append(lagMetrics, blip.MetricValue{
+			Name:  "current",
+			Type:  blip.GAUGE,
+			Group: map[string]string{"channel": channel},
+			Value: lag.current,
+		})
+		backlog = math.Max(backlog, float64(lag.backlog))
+		workerUsage = math.Max(lag.workerUsage, workerUsage)
+		blip.Debug("(repl.lag from PFS): channel: %s txID: %s Observed State: %s Num of applying workers: %d | backlog: %3d worker Usage: %3.2f%% lag=%d ms", channel, lag.trxId, lag.observed, lag.applying, lag.backlog, lag.workerUsage, int(lag.current))
+	}
+	if len(lagMetrics) > 0 {
+		lagMetrics = append(lagMetrics, blip.MetricValue{
+			Name:  "backlog",
+			Type:  blip.GAUGE,
+			Value: backlog,
+		})
+		lagMetrics = append(lagMetrics, blip.MetricValue{
+			Name:  "worker_usage",
+			Type:  blip.GAUGE,
+			Value: backlog,
+		})
+	}
+
+	return lagMetrics, nil
+}
+
+func lagFor(workers []worker, lastQueued, lastProc map[string]string) lag {
+	lag := lag{}                  // return value
+	channel := workers[0].channel // for brevity
+	maxTrxNo := 0                 //  backlog = last queued trxNo - maxTrxNo
+	var (
+		oldestApplyingTs float64
+		lastAppliedTs    float64
+		lastAppliedLag   float64
+	)
+
+	for _, w := range workers {
+		// Count workers that are applying and save the oldest (longest running)
+		// one because we report worst case lag. For example, given trx set 1-10,
+		// if worker1 is applying trx 5, and worker2 is applying trx 9, lag is
+		// 10-5=5 not 10-9=1.
+		if w.applyingTs > 0 { // worker is applying
+			lag.applying += 1
+			if w.applyingTs < oldestApplyingTs || lag.applying == 1 {
+				oldestApplyingTs = w.applyingTs
+			}
+		}
+
+		// Save max worker trx number (GTID). Later, if no workers are applying,
+		// this is point at which the replica has caught up. It's also used to
+		// calculate the backlog (optimistically presuming any gaps will be applied
+		// successfully).
+		n := trxNo(w.lastAppliedTrx)
+		if n > maxTrxNo {
+			maxTrxNo = n
+			lastAppliedTs = w.lastAppliedTs
+			lastAppliedLag = w.lastAppliedLag
+			lag.trxId = w.lastAppliedTrx
+		}
+
+		//
+		// If-else order matters here! Read the comments top to bottom.
+		//
+		// NOTE: ts are seconds (e.g. 1716922205.641072) so multiply by 1000
+		// for milliseconds. But the one lag value, lastAppliedLag, is microseconds,
+		// so divide by 1000 for milliseconds.
+		//
+		if lag.applying > 0 {
+			// At least one worker is applying, so report worst case applying lag.
+			// See comments above re oldestApplyingTs. Ignore applied trx/lag and
+			// thread state for now because as long as a worker/trx is applying,
+			// it's a reliable "signal" of lag, like receiving a heartbeat. If the
+			// replica is actually dead, eventually no workers will be applying and
+			// one of the if-else cases below will be true.
+			lag.current = math.Floor((workers[0].now - oldestApplyingTs) * 1000.0) // as milliseconds
+			lag.observed = O_APPLYING
+
+		} else if workers[0].lastQueuedTrx != lastQueued[channel] {
+			// No workers are applying (all are idle) but the replica received new
+			// trx since last time we looked. This means replication is working.
+			// If we report lag = NOW - last applied ts, then we introduce an artifact:
+			// polling time. If polling every 5s and the last applied trx happened
+			// 4s ago, it'll look like 4s of lag even if the trx lagged only 100ms.
+			// Since repl events arrive randomly (they're not fixed interval heartbeats)
+			// and Blip can be configured to poll (collect repl.lag) at any interval,
+			// this won't work well. Instead, we know only one thing for sure:
+			//   last applied lag =
+			//     LAST_APPLIED_TRANSACTION_END_APPLY_TIMESTAMP - LAST_APPLIED_TRANSACTION_IMMEDIATE_COMMIT_TIMESTAMP
+			// Those column values come from the max worker trx number (see comments
+			// above), so it's the lag of the last applied trx as measured from
+			// source to replica, irrespective of polling frequency or current time.
+			// In the example above, this trx might have lagged only 100ms, and then
+			// we observe it 4.9s later but correctly report 100ms. -- This is a bit
+			// of an edge case where appliers do work in between observations,
+			// probably because replica isn't super busy so trx are quick and
+			// intermittent. Reporting zero would be misleading now that we can
+			// look back and see objective lag recorded by MySQL in these tables.
+			lag.current = math.Floor(lastAppliedLag / 1000.0) // as milliseconds
+			lag.observed = O_RECEIVED
+
+		} else if workers[0].ioThd != "ON" || workers[0].sqlThd != "ON" {
+			// No workers applying and no trx received. If either repl thread is
+			// not in a known good state, then we err on the side of caution and
+			// report increasing lag from the time of the last applied trx.
+			// This has become industry standard practice: a stopped replica means
+			// lag increases. If someone isn't monitoring thread state, this might
+			// be the only way they detect that the replica has stopped (presuming
+			// they're monitoring/alerting on high repl lag).
+			lag.current = math.Floor((workers[0].now - lastAppliedTs) * 1000.0) // as milliseconds
+			lag.observed = O_STOPPED
+
+		} else {
+			// Not applying, not received any trx, and threads are both ok:
+			// this is true zero repl lag. The source or network might be having
+			// an issue, but those are outside the replica, so not something we
+			// can reliably measure or report. From the replica point of view,
+			// there is/was truly no work since we last looked. -- Since we
+			// presume the replica should be busy, this can (and should) be
+			// used for an alert: if lag = 0 for 5 minutes -> alert.
+			lag.current = 0
+			lag.observed = O_IDLE
+		}
+	}
+
+	lag.backlog = trxNo(workers[0].lastQueuedTrx) - maxTrxNo
+	lag.workerUsage = float64(lag.applying) / float64(len(workers)) * 100
+
+	// Save observed trx for calculations in next call. All workers have
+	// same value (because they come from repl conn status and coordinator
+	// tables) so workers[0] is used.
+	lastQueued[channel] = workers[0].lastQueuedTrx
+	lastProc[channel] = workers[0].lastProcTrx
+
+	return lag
+}
+
+// trxNo takes a GTID like a930bd5c-1e21-11ef-a9a6-0242ac1c000a:1234 and returns 1234.
+func trxNo(gtid string) int {
+	if gtid == "" {
+		return 0
+	}
+	trxNo, err := strconv.Atoi(gtid[strings.IndexRune(gtid, ':')+1:])
+	if err != nil {
+		panic("invalid GTID: " + gtid)
+	}
+	return trxNo
+}

--- a/metrics/repl.lag/pfs.go
+++ b/metrics/repl.lag/pfs.go
@@ -140,6 +140,7 @@ func (c *Lag) collectPFS(ctx context.Context, levelName string) ([]blip.MetricVa
 			Value: lag.workerUsage,
 			Group: map[string]string{"channel": channel},
 		})
+		fmt.Printf("(repl.lag from PFS): channel: %s txID: %s Observed State: %s Num of applying workers: %d | backlog: %3d worker Usage: %3.2f%% lag=%d ms", channel, lag.trxId, lag.observed, lag.applying, lag.backlog, lag.workerUsage, int(lag.current))
 		blip.Debug("(repl.lag from PFS): channel: %s txID: %s Observed State: %s Num of applying workers: %d | backlog: %3d worker Usage: %3.2f%% lag=%d ms", channel, lag.trxId, lag.observed, lag.applying, lag.backlog, lag.workerUsage, int(lag.current))
 	}
 	return lagMetrics, nil

--- a/metrics/repl.lag/pfs.go
+++ b/metrics/repl.lag/pfs.go
@@ -92,9 +92,6 @@ func (c *Lag) collectPFS(ctx context.Context, levelName string) ([]blip.MetricVa
 		return defaultLag, nil
 	}
 
-	lastQueued := map[string]string{} // by replica/to relay log
-	lastProc := map[string]string{}   // by coordinator/to workers
-
 	rows, err := c.db.QueryContext(context.Background(), mySQL8LagQuery)
 	if err != nil {
 		return nil, fmt.Errorf("could not check replication lag, check that the host is a MySQL 8.0 replica, and that performance_schema is enabled. Err: %s", err.Error())

--- a/metrics/repl.lag/pfs.go
+++ b/metrics/repl.lag/pfs.go
@@ -65,7 +65,7 @@ const (
 	O_IDLE     = " " // none of the above == true zero lag
 )
 
-func (c *Lag) collectPFSv2(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+func (c *Lag) collectPFS(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
 	var defaultLag []blip.MetricValue
 	if c.dropNotAReplica[levelName] {
 		defaultLag = nil

--- a/test/docker/docker-compose.yaml
+++ b/test/docker/docker-compose.yaml
@@ -3,6 +3,7 @@ name: blip
 services:
     mysql57:
         image: mysql:5.7.34
+        platform: linux/amd64
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         environment:
@@ -11,6 +12,7 @@ services:
             - "33570:3306"
     mysql80:
         image: mysql:8.0.34
+        platform: linux/amd64
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         environment:
@@ -19,6 +21,7 @@ services:
             - "33800:3306"
     percona57:
         image: percona/percona-server:5.7.35
+        platform: linux/amd64
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         environment:

--- a/test/plans/default.yaml
+++ b/test/plans/default.yaml
@@ -8,7 +8,8 @@ kpi:
         - read_only
       options: {}  # Needed so tests don't get a nil map
     repl.lag:
-      options: {}  # Needed so tests don't get a nil map
+      options:
+        writer: auto
     status.global:
       options:
         source: auto

--- a/test/plans/default.yaml
+++ b/test/plans/default.yaml
@@ -8,7 +8,7 @@ kpi:
         - read_only
       options: {}  # Needed so tests don't get a nil map
     repl.lag:
-      options: {}
+      options: {}  # Needed so tests don't get a nil map
     status.global:
       options:
         source: auto

--- a/test/plans/default.yaml
+++ b/test/plans/default.yaml
@@ -7,6 +7,8 @@ kpi:
       metrics:
         - read_only
       options: {}  # Needed so tests don't get a nil map
+    repl.lag:
+      options: {}
     status.global:
       options:
         source: auto


### PR DESCRIPTION
This follows the same pattern `var.global` uses to add options for collecting replication lag from performance schema.

I haven't updated the doc yet, as it seems current `repl.log` collector usage is documented in `Heartbeat` section, it probably doesn't make sense to add the `pfs` option in that page. So we have to restructure the doc a bit to document this update.