### PR TITLE
Initialize engine v2 with Ian's original PR

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -110,7 +109,7 @@ func LoadConfig(filePath string, cfg Config, required bool) (Config, error) {
 		return cfg, nil
 	}
 
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		// err includes file name, e.g. "read config file: open <file>: no such file or directory"
 		return Config{}, fmt.Errorf("cannot read config file: %s", err)
@@ -1082,7 +1081,7 @@ func (c ConfigTLS) LoadTLS(server string) (*tls.Config, error) {
 
 	// Root CA (optional)
 	if c.CA != "" {
-		caCert, err := ioutil.ReadFile(c.CA)
+		caCert, err := os.ReadFile(c.CA)
 		if err != nil {
 			return nil, err
 		}
@@ -1100,7 +1099,7 @@ func (c ConfigTLS) LoadTLS(server string) (*tls.Config, error) {
 		}
 
 		tlsConfig.Certificates = []tls.Certificate{cert}
-		tlsConfig.BuildNameToCertificate()
+		//tlsConfig.BuildNameToCertificate()
 	}
 
 	return tlsConfig, nil

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  # MySQL 8.0
+  mysql80:
+    image: percona/percona-server:8.0.32
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: "test"
+      MYSQL_USER: user
+      MYSQL_PASSWORD: pass
+    ports:
+      - "33800:3306"
+
+  mysql57:
+    image: percona/percona-server:5.7
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: "test"
+      MYSQL_USER: user
+      MYSQL_PASSWORD: pass
+    ports:
+      - "33570:3306"

--- a/monitor/level_collector_test.go
+++ b/monitor/level_collector_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cashapp/blip"
@@ -103,13 +104,20 @@ func TestLevelCollector(t *testing.T) {
 	monitor.TickerDuration(10 * time.Millisecond)
 	defer monitor.TickerDuration(1 * time.Second)
 
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			t.Logf("Got metrics: %s", m.MonitorId)
+			return nil
+		},
+	}
+
 	// Create LCO and and run it, but it starts paused until ChangePlan is called
 	// starts working once a plan is set.
 	lpc := monitor.NewLevelCollector(monitor.LevelCollectorArgs{
 		Config:     moncfg,
 		DB:         db,
 		PlanLoader: pl,
-		Sinks:      []blip.Sink{mock.Sink{}},
+		Sinks:      []blip.Sink{mockSink},
 	})
 	stopChan := make(chan struct{})
 	doneChan := make(chan struct{})
@@ -165,6 +173,623 @@ func TestLevelCollector(t *testing.T) {
 	}
 	assert.ElementsMatch(t, gotLevels[:12], expectLevels)
 	mux.Unlock()
+}
+
+func TestLevelCollector_SinkProcessing(t *testing.T) {
+	// Verify that values collected are sent to the sink
+	// in the order they were collected. None of the values
+	// should be dropped or missed
+
+	// Create and register a mock blip.Collector that saves the level name
+	// every time it's called. This is quite deep within the call stack,
+	// which is what we want: LCO->engine->collector. By using a fake collector
+	// but real LCO and enginer, we testing the real, unmodified logic--
+	// the LCO and engine don't know or care that this collector is a mock.
+	_, db, err := test.Connection("mysql57")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	monitorId := "m1"
+	defer status.RemoveMonitor(monitorId)
+
+	mux := &sync.Mutex{}
+	indexMux := &sync.Mutex{}
+	index := 0
+	gotMetrics := [][]blip.MetricValue{}
+
+	metricValues := [][]blip.MetricValue{}
+	for i := 0; i < 20; i++ {
+		metricValues = append(metricValues, []blip.MetricValue{
+			{
+				Name:  "test-metric",
+				Value: float64(i),
+				Type:  blip.GAUGE,
+			}})
+	}
+
+	mc := mock.MetricsCollector{
+		CollectFunc: func(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+			indexMux.Lock()
+			defer indexMux.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+			value := metricValues[index]
+			index = index + 1
+			if index >= len(metricValues) {
+				index = 0
+			}
+			return value, nil
+		},
+	}
+	mf := mock.MetricFactory{
+		MakeFunc: func(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+			return mc, nil
+		},
+	}
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			mux.Lock()
+			gotMetrics = append(gotMetrics, m.Values["test"])
+			mux.Unlock()
+			return nil
+		},
+	}
+	metrics.Register(mc.Domain(), mf) // MUST CALL FIRST, before the rest...
+	defer metrics.Remove(mc.Domain())
+
+	// Make a mini, fake config that uses the test plan and load it realistically
+	// because the plan loader combines and sorts levels, etc. This is a lot of
+	// boilerplate, but it ensure we test a realistic LCO and monitor--only the
+	// collector is fake.
+	planName := "../test/plans/lpc_1_5_10.yaml"
+	moncfg := blip.ConfigMonitor{
+		MonitorId: monitorId,
+		Username:  "root",
+		Password:  "test",
+		Hostname:  "127.0.0.1:33560", // 5.6
+	}
+	cfg := blip.Config{
+		Plans:    blip.ConfigPlans{Files: []string{planName}},
+		Monitors: []blip.ConfigMonitor{moncfg},
+	}
+	moncfg.ApplyDefaults(cfg)
+
+	dbMaker := dbconn.NewConnFactory(nil, nil)
+	pl := plan.NewLoader(nil)
+
+	if err := pl.LoadShared(cfg.Plans, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+	if err := pl.LoadMonitor(moncfg, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before running the LCO, change its internal ticker interval so we can test
+	// this quickly rather than waiting a real 10s
+	monitor.TickerDuration(10 * time.Millisecond)
+	defer monitor.TickerDuration(1 * time.Second)
+
+	// Create LCO and and run it, but it starts paused until ChangePlan is called
+	// starts working once a plan is set.
+	lpc := monitor.NewLevelCollector(monitor.LevelCollectorArgs{
+		Config:     moncfg,
+		DB:         db,
+		PlanLoader: pl,
+		Sinks:      []blip.Sink{mockSink},
+	})
+	stopChan := make(chan struct{})
+	doneChan := make(chan struct{})
+	go lpc.Run(stopChan, doneChan)
+
+	// Wait a few ticks and check LCO status to verify that is, in fact, paused
+	time.Sleep(100 * time.Millisecond)
+	s := status.ReportMonitors(monitorId)
+	if !strings.Contains(s[monitorId][status.LEVEL_COLLECTOR], "paused") {
+		t.Errorf("LCO not paused, expected it to be paused until ChangePlan is called (status=%+v)", s)
+	}
+
+	// ChangePlan sets the plan and un-pauses (starts collecting the new plan).
+	// So call that and wait 15 ticks (150ms / 10s), then close the stopChan
+	// to stop the LCO (don't leak goroutines)
+	lpc.ChangePlan(blip.STATE_ACTIVE, planName) // set plan, start collecting metrics
+	time.Sleep(150 * time.Millisecond)
+	close(stopChan)
+	select {
+	case <-doneChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for LCO to stop")
+	}
+
+	// LCO should have experienced 15s of running in 150ms because we set the
+	// TickerDuration to 10ms (instead of its default 1s). That means the mock
+	// collector should have been called 15 times, but CI systems can be really
+	// slow, so we'll allow 15 or 16 calls.
+	mux.Lock()
+	if len(gotMetrics) > 16 {
+		t.Errorf("got %d metric values, expected 15 (exactxly) or 16 (at most)", len(gotMetrics))
+	}
+
+	// If leveled collection is working properly, the first 12 metric values collected--
+	// as called by the LCO to engine.Collect--should be this sequence:
+	if len(gotMetrics) < 12 {
+		t.Fatalf("got %d metric values, expected at least 12", len(gotMetrics))
+	}
+
+	if diff := deep.Equal(gotMetrics[:12], metricValues[:12]); diff != nil {
+		t.Error(diff)
+	}
+	mux.Unlock()
+}
+
+func TestLevelCollector_CancelCollector(t *testing.T) {
+	// Verify that a long-running collector is properly
+	// halted when the next instance of that collector
+	// needs to start.
+
+	// Create and register a mock blip.Collector that saves the level name
+	// every time it's called. This is quite deep within the call stack,
+	// which is what we want: LCO->engine->collector. By using a fake collector
+	// but real LCO and enginer, we testing the real, unmodified logic--
+	// the LCO and engine don't know or care that this collector is a mock.
+	_, db, err := test.Connection("mysql57")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	monitorId := "m1"
+	defer status.RemoveMonitor(monitorId)
+
+	mux := &sync.Mutex{}
+	indexMux := &sync.Mutex{}
+	index := 0
+	gotMetrics := [][]blip.MetricValue{}
+
+	metricValues := [][]blip.MetricValue{}
+	for i := 0; i < 20; i++ {
+		metricValues = append(metricValues, []blip.MetricValue{
+			{
+				Name:  "test-metric",
+				Value: float64(i),
+				Type:  blip.GAUGE,
+			}})
+	}
+
+	mc := mock.MetricsCollector{
+		CollectFunc: func(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+			indexMux.Lock()
+			defer indexMux.Unlock()
+			value := metricValues[index]
+			index = index + 1
+			if index >= len(metricValues) {
+				index = 0
+			}
+
+			// Simulate a long-running collector
+			if index == 5 {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+
+			return value, nil
+		},
+	}
+	mf := mock.MetricFactory{
+		MakeFunc: func(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+			return mc, nil
+		},
+	}
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			mux.Lock()
+			if values, ok := m.Values["test"]; ok {
+				gotMetrics = append(gotMetrics, values)
+			}
+			mux.Unlock()
+			return nil
+		},
+	}
+	metrics.Register(mc.Domain(), mf) // MUST CALL FIRST, before the rest...
+	defer metrics.Remove(mc.Domain())
+
+	// Make a mini, fake config that uses the test plan and load it realistically
+	// because the plan loader combines and sorts levels, etc. This is a lot of
+	// boilerplate, but it ensure we test a realistic LCO and monitor--only the
+	// collector is fake.
+	planName := "../test/plans/lpc_1_5_10.yaml"
+	moncfg := blip.ConfigMonitor{
+		MonitorId: monitorId,
+		Username:  "root",
+		Password:  "test",
+		Hostname:  "127.0.0.1:33560", // 5.6
+	}
+	cfg := blip.Config{
+		Plans:    blip.ConfigPlans{Files: []string{planName}},
+		Monitors: []blip.ConfigMonitor{moncfg},
+	}
+	moncfg.ApplyDefaults(cfg)
+
+	dbMaker := dbconn.NewConnFactory(nil, nil)
+	pl := plan.NewLoader(nil)
+
+	if err := pl.LoadShared(cfg.Plans, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+	if err := pl.LoadMonitor(moncfg, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before running the LCO, change its internal ticker interval so we can test
+	// this quickly rather than waiting a real 10s
+	monitor.TickerDuration(10 * time.Millisecond)
+	defer monitor.TickerDuration(1 * time.Second)
+
+	// Create LCO and and run it, but it starts paused until ChangePlan is called
+	// starts working once a plan is set.
+	lpc := monitor.NewLevelCollector(monitor.LevelCollectorArgs{
+		Config:     moncfg,
+		DB:         db,
+		PlanLoader: pl,
+		Sinks:      []blip.Sink{mockSink},
+	})
+	stopChan := make(chan struct{})
+	doneChan := make(chan struct{})
+	go lpc.Run(stopChan, doneChan)
+
+	// Wait a few ticks and check LCO status to verify that is, in fact, paused
+	time.Sleep(100 * time.Millisecond)
+	s := status.ReportMonitors(monitorId)
+	if !strings.Contains(s[monitorId][status.LEVEL_COLLECTOR], "paused") {
+		t.Errorf("LCO not paused, expected it to be paused until ChangePlan is called (status=%+v)", s)
+	}
+
+	// ChangePlan sets the plan and un-pauses (starts collecting the new plan).
+	// So call that and wait 15 ticks (150ms / 10s), then close the stopChan
+	// to stop the LCO (don't leak goroutines)
+	lpc.ChangePlan(blip.STATE_ACTIVE, planName) // set plan, start collecting metrics
+	time.Sleep(150 * time.Millisecond)
+	close(stopChan)
+	select {
+	case <-doneChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for LCO to stop")
+	}
+
+	// LCO should have experienced 15s of running in 150ms because we set the
+	// TickerDuration to 10ms (instead of its default 1s). That means the mock
+	// collector should have been called 15 times, but CI systems can be really
+	// slow, so we'll allow 15 or 16 calls.
+	mux.Lock()
+	if len(gotMetrics) > 16 {
+		t.Errorf("got %d metric values, expected 15 (exactly) or 16 (at most)", len(gotMetrics))
+	}
+
+	// If leveled collection is working properly, the first 12 metric values collected--
+	// as called by the LCO to engine.Collect--should be this sequence:
+	if len(gotMetrics) < 12 {
+		t.Fatalf("got %d metric values, expected at least 12", len(gotMetrics))
+	}
+
+	if diff := deep.Equal(gotMetrics[:12], metricValues[:12]); diff != nil {
+		t.Error(diff)
+	}
+	mux.Unlock()
+}
+
+type metricPayload struct {
+	metrics []blip.MetricValue
+	err     error
+}
+
+func makeProgressiveCollector(t *testing.T) *mock.MetricsCollector {
+	var cleanupCtx context.Context
+
+	index := 0
+	metricValues := [][]blip.MetricValue{}
+	for i := 0; i < 20; i++ {
+		metricValues = append(metricValues, []blip.MetricValue{
+			{
+				Name:  "test-metric",
+				Value: float64(i),
+				Type:  blip.GAUGE,
+			}})
+	}
+
+	requestChan := make(chan context.Context)
+	flushChan := make(chan metricPayload)
+	running := false
+	var mx sync.Mutex
+
+	timerDuration := []time.Duration{5 * time.Millisecond, 60 * time.Millisecond}
+
+	run := func() {
+		defer func() {
+			mx.Lock()
+			running = false
+			mx.Unlock()
+		}()
+
+		for {
+			localCtx := context.Background()
+
+			t.Log("Starting collection loop")
+			tc := time.NewTicker(timerDuration[index%len(timerDuration)])
+			value := metricValues[index]
+			index = index + 1
+			if index >= len(metricValues) {
+				index = 0
+			}
+
+		RETRY_OUTPUT:
+			select {
+			case <-localCtx.Done():
+				t.Log("Collector got a request for metrics")
+				// Caller requires an update
+				// e.g. Domain timeout
+				flushChan <- metricPayload{
+					metrics: value,
+				}
+				// Switch back to a default context now that we have given the caller what they need
+				localCtx = context.Background()
+			case newCtx := <-requestChan:
+				// collector started a new pass
+				// so we need the context for that pass
+				// Once we get it immediately check to see if we need to return metrics
+				localCtx = newCtx
+				goto RETRY_OUTPUT
+			case <-tc.C:
+				t.Log("Collector finished query, sending metrics")
+				// Simulate that our results are "done"
+				flushChan <- metricPayload{
+					metrics: value,
+				}
+				tc.Stop()
+				// Switch back to a default context now that we have given the caller what they need
+				localCtx = context.Background()
+				return
+
+			case <-cleanupCtx.Done():
+				t.Log("Collector is stopping")
+				// The cleanup has been called on the collector
+				close(flushChan)
+				close(requestChan)
+				tc.Stop()
+				return
+			}
+
+			tc.Stop()
+		}
+
+	}
+
+	longMc := mock.MetricsCollector{
+		PrepareFunc: func(ctx context.Context, plan blip.Plan) (func(), error) {
+			ctx, cleanupFn := context.WithCancel(context.Background())
+			cleanupCtx = ctx
+			return func() {
+				cleanupFn()
+			}, nil
+		},
+		DomainFunc: func() string {
+			return "long"
+		},
+		CollectFunc: func(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+			t.Logf("Entering collector: %s", levelName)
+			mx.Lock()
+			if !running {
+				t.Log("Starting new collector")
+				running = true
+				go run()
+			}
+			mx.Unlock()
+
+			t.Logf("Waiting for metrics: %s", levelName)
+			// Pass the internal collector the context for this pass
+			requestChan <- ctx
+			// We will now get a result from the internal collector,
+			// either due to it finishing or because our context ended
+			payload, ok := <-flushChan
+			t.Log("Got payload from collector")
+			if !ok {
+				return nil, fmt.Errorf("Collector closed")
+			}
+			return payload.metrics, payload.err
+		},
+	}
+
+	return &longMc
+}
+
+func TestLevelCollector_ProgressiveCollector(t *testing.T) {
+	//blip.Debugging = true
+	// Verifies that a collect progressive returns
+	// results when it's next run comes up.
+
+	// Create and register a mock blip.Collector that saves the level name
+	// every time it's called. This is quite deep within the call stack,
+	// which is what we want: LCO->engine->collector. By using a fake collector
+	// but real LCO and enginer, we testing the real, unmodified logic--
+	// the LCO and engine don't know or care that this collector is a mock.
+	_, db, err := test.Connection("mysql57")
+	if err != nil {
+		if test.Build {
+			t.Skip("mysql57 not running")
+		} else {
+			t.Fatal(err)
+		}
+	}
+	defer db.Close()
+
+	monitorId := "m1"
+	defer status.RemoveMonitor(monitorId)
+
+	mux := &sync.Mutex{}
+	indexMux := &sync.Mutex{}
+	index := 0
+	gotMetrics := [][]blip.MetricValue{}
+	longMetrics := [][]blip.MetricValue{}
+
+	metricValues := [][]blip.MetricValue{}
+	for i := 0; i < 20; i++ {
+		metricValues = append(metricValues, []blip.MetricValue{
+			{
+				Name:  "test-metric",
+				Value: float64(i),
+				Type:  blip.GAUGE,
+			}})
+	}
+
+	mc := mock.MetricsCollector{
+		CollectFunc: func(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+			indexMux.Lock()
+			defer indexMux.Unlock()
+			value := metricValues[index]
+			index = index + 1
+			if index >= len(metricValues) {
+				index = 0
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			return value, nil
+		},
+	}
+
+	longMc := makeProgressiveCollector(t)
+
+	mf := mock.MetricFactory{
+		MakeFunc: func(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+			if domain == "long" {
+				return longMc, nil
+			}
+			return mc, nil
+		},
+	}
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			mux.Lock()
+			if values, ok := m.Values["test"]; ok {
+				gotMetrics = append(gotMetrics, values)
+			}
+			if values, ok := m.Values["long"]; ok {
+				longMetrics = append(longMetrics, values)
+			}
+			mux.Unlock()
+			return nil
+		},
+	}
+	metrics.Register(mc.Domain(), mf) // MUST CALL FIRST, before the rest...
+	metrics.Register(longMc.Domain(), mf)
+	defer metrics.Remove(mc.Domain())
+	defer metrics.Remove(longMc.Domain())
+
+	// Make a mini, fake config that uses the test plan and load it realistically
+	// because the plan loader combines and sorts levels, etc. This is a lot of
+	// boilerplate, but it ensure we test a realistic LCO and monitor--only the
+	// collector is fake.
+	planName := "../test/plans/lpc_2_domains.yaml"
+	moncfg := blip.ConfigMonitor{
+		MonitorId: monitorId,
+		Username:  "root",
+		Password:  "test",
+		Hostname:  "127.0.0.1:33560", // 5.6
+	}
+	cfg := blip.Config{
+		Plans:    blip.ConfigPlans{Files: []string{planName}},
+		Monitors: []blip.ConfigMonitor{moncfg},
+	}
+	moncfg.ApplyDefaults(cfg)
+
+	dbMaker := dbconn.NewConnFactory(nil, nil)
+	pl := plan.NewLoader(nil)
+
+	if err := pl.LoadShared(cfg.Plans, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+	if err := pl.LoadMonitor(moncfg, dbMaker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before running the LCO, change its internal ticker interval so we can test
+	// this quickly rather than waiting a real 10s
+	monitor.TickerDuration(10 * time.Millisecond)
+	defer monitor.TickerDuration(1 * time.Second)
+
+	// Create LCO and and run it, but it starts paused until ChangePlan is called
+	// starts working once a plan is set.
+	lpc := monitor.NewLevelCollector(monitor.LevelCollectorArgs{
+		Config:     moncfg,
+		DB:         db,
+		PlanLoader: pl,
+		Sinks:      []blip.Sink{mockSink},
+	})
+	stopChan := make(chan struct{})
+	doneChan := make(chan struct{})
+	go lpc.Run(stopChan, doneChan)
+
+	// Wait a few ticks and check LCO status to verify that is, in fact, paused
+	time.Sleep(100 * time.Millisecond)
+	s := status.ReportMonitors(monitorId)
+	if !strings.Contains(s[monitorId][status.LEVEL_COLLECTOR], "paused") {
+		t.Errorf("LCO not paused, expected it to be paused until ChangePlan is called (status=%+v)", s)
+	}
+
+	// ChangePlan sets the plan and un-pauses (starts collecting the new plan).
+	// So call that and wait 15 ticks (150ms / 10s), then close the stopChan
+	// to stop the LCO (don't leak goroutines)
+	lpc.ChangePlan(blip.STATE_ACTIVE, planName) // set plan, start collecting metrics
+	time.Sleep(150 * time.Millisecond)
+	close(stopChan)
+	t.Log("Starting wait for LCO to stop")
+	select {
+	case <-doneChan:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for LCO to stop")
+	}
+
+	// LCO should have experienced 15s of running in 150ms because we set the
+	// TickerDuration to 10ms (instead of its default 1s). That means the mock
+	// collector should have been called 15 times, but CI systems can be really
+	// slow, so we'll allow 15 or 16 calls.
+	mux.Lock()
+	defer mux.Unlock()
+	if len(gotMetrics) > 16 {
+		t.Errorf("got %d metric values, expected 15 (exactly) or 16 (at most)", len(gotMetrics))
+	}
+
+	// If leveled collection is working properly, the first 12 metric values collected--
+	// as called by the LCO to engine.Collect--should be this sequence:
+	if len(gotMetrics) < 12 {
+		t.Fatalf("got %d metric values, expected at least 12", len(gotMetrics))
+	}
+
+	if len(longMetrics) < 2 {
+		t.Fatalf("got %d metric values from 'long' domain, expected at least 2", len(longMetrics))
+	}
+
+	if diff := deep.Equal(gotMetrics[:12], metricValues[:12]); diff != nil {
+		t.Error(diff)
+	}
+	if diff := deep.Equal(longMetrics[:2], metricValues[:2]); diff != nil {
+		t.Error(diff)
+	}
 }
 
 func TestLevelCollectorChangePlan(t *testing.T) {

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -320,7 +320,7 @@ func (m *Monitor) startup() error {
 
 	// ----------------------------------------------------------------------
 	// Exporter API (Prometheus emulation)
-
+	// TODO: This need to collect metrics synchronously
 	if m.cfg.Exporter.Mode != "" {
 		status.Monitor(m.monitorId, status.MONITOR, "starting exporter")
 

--- a/monitor/mysqld_exporter.go
+++ b/monitor/mysqld_exporter.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cashapp/blip/prom"
 )
 
-// Exporter emulates a Prometheus mysqld_exporter. It implement prom.Exporter.
+// Exporter emulates a Prometheus mysqld_exporter. It implements prom.Exporter.
 type Exporter struct {
 	cfg    blip.ConfigExporter
 	plan   blip.Plan
@@ -75,7 +75,7 @@ func (e Exporter) Describe(descs chan<- *prometheus.Desc) {
 
 var noop = func() {}
 
-// Collect collects metrics. It is called indirectly via Scrpe.
+// Collect collects metrics. It is called indirectly via Scrape.
 func (e Exporter) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -91,7 +91,7 @@ func (e Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 	e.Unlock()
 
-	metrics, err := e.engine.Collect(ctx, "prom")
+	metrics, err := e.engine.CollectSynchronous(ctx, "prom")
 	if err != nil {
 		e.event.Errorf(event.ENGINE_COLLECT_ERROR, "%s; see monitor status or event log for details", err)
 	}

--- a/sink/datadog_test.go
+++ b/sink/datadog_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,7 +101,7 @@ func getPayloadSize(r *http.Request) (int, error) {
 	}
 
 	defer bodyReader.Close()
-	body, err := ioutil.ReadAll(bodyReader)
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		return 0, err
 	}
@@ -251,7 +252,7 @@ func TestDatadogMetricsPerRequestMultipleFail(t *testing.T) {
 				var payload datadogV2.MetricPayload
 				body, _ := r.GetBody()
 				defer body.Close()
-				data, _ := ioutil.ReadAll(body)
+				data, _ := io.ReadAll(body)
 				json.Unmarshal(data, &payload)
 
 				for _, metric := range payload.Series {
@@ -331,7 +332,7 @@ func TestDatadogMetricsErrorResponseFromAPI(t *testing.T) {
 			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusAccepted,
-					Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
+					Body:       io.NopCloser(bytes.NewReader(respJSON)),
 				}, nil
 			},
 		},
@@ -360,7 +361,7 @@ func TestDatadogCounterMetricsDeltaCalculation(t *testing.T) {
 				var payload datadogV2.MetricPayload
 				body, _ := r.GetBody()
 				defer body.Close()
-				data, _ := ioutil.ReadAll(body)
+				data, _ := io.ReadAll(body)
 				json.Unmarshal(data, &payload)
 
 				for _, metric := range payload.Series {
@@ -423,6 +424,379 @@ func TestDatadogCounterMetricsDeltaCalculation(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedMetrics = getExpectedMetrics(blipMetricsFourthBatch, blipMetricsThirdBatch)
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestDatadogCounterMetricsDeltaCalculation_DeltaSink(t *testing.T) {
+	callCount := 0
+	metricCount := 50
+	trCount := 0
+	collectedMetrics := map[string]float64{}
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				callCount++
+
+				var payload datadogV2.MetricPayload
+				body, _ := r.GetBody()
+				defer body.Close()
+				data, _ := io.ReadAll(body)
+				json.Unmarshal(data, &payload)
+
+				for _, metric := range payload.Series {
+					require.Equal(t, 1, len(metric.Points), "metric series should have only 1 metric")
+					collectedMetrics[metric.Metric] = *metric.Points[0].Value
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ops["api-compress"] = "false" // Turn off compression so that we get easier calculations for sizing
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	require.NoError(t, err)
+	ddSink.tr = &mock.Tr{
+		TranslateFunc: func(domain, metric string) string {
+			trCount++
+			return fmt.Sprintf("%s.%s", domain, metric)
+		},
+	}
+
+	deltaSink := NewDelta(ddSink)
+
+	blipMetricsFirstBatch := getBlipCounterMetrics(metricCount, 10.0, true)
+	err = deltaSink.Send(context.Background(), blipMetricsFirstBatch)
+	require.NoError(t, err)
+	// only half the metrics with Delta counter values should be sent
+	require.Equal(t, metricCount/2, len(collectedMetrics))
+	expectedMetrics := map[string]float64{}
+	for _, metric := range blipMetricsFirstBatch.Values["testdomain"] {
+		if metric.Type == blip.DELTA_COUNTER {
+			name := fmt.Sprintf("testdomain.%s", metric.Name)
+			expectedMetrics[name] = metric.Value
+		}
+	}
+	// reset collected
+	collectedMetrics = map[string]float64{}
+	blipMetricsSecondBatch := getBlipCounterMetrics(metricCount, 20.0, true)
+	err = deltaSink.Send(context.Background(), blipMetricsSecondBatch)
+	require.NoError(t, err)
+
+	expectedMetrics = getExpectedMetrics(blipMetricsSecondBatch, blipMetricsFirstBatch)
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+
+	// simulate a restart
+	blipMetricsThirdBatch := getBlipCounterMetrics(metricCount, 1.0, true)
+	err = deltaSink.Send(context.Background(), blipMetricsThirdBatch)
+	require.Equal(t, metricCount, len(collectedMetrics))
+
+	// reset collected
+	collectedMetrics = map[string]float64{}
+
+	// send final batch
+	blipMetricsFourthBatch := getBlipCounterMetrics(metricCount, 5.0, true)
+	err = deltaSink.Send(context.Background(), blipMetricsFourthBatch)
+	require.NoError(t, err)
+
+	expectedMetrics = getExpectedMetrics(blipMetricsFourthBatch, blipMetricsThirdBatch)
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+// This test demonstrates the errors that can arise from the delta calculations
+// in the Datadog sink when it is wrapped in a Retry sink and an error occurs.
+// When multiple metric batch have been buffered by the retry sink and an error
+// occurs, the retry mechanism will start processing a *newer* metric batch
+// which causes the delta calculation to not work properly.
+func TestDatadogCounterMetricsDeltaCalculation_RetrySink(t *testing.T) {
+	metricCount := 50
+	collectedMetrics := map[string]float64{}
+
+	// Create controls for handling the timing
+	// of goroutines so we can coordinate the scenario
+	var wg sync.WaitGroup
+	failChan := make(chan bool, 2)
+	enteredChan := make(chan struct{})
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				// Track when the submission is running
+				wg.Add(1)
+				defer wg.Done()
+
+				// Wait for the caller to confirm that it knows that
+				// the submission has started
+				enteredChan <- struct{}{}
+
+				// Determine if the submission should fail or not
+				shouldFail := <-failChan
+				if shouldFail {
+					return nil, fmt.Errorf("Test Failure")
+				}
+
+				var payload datadogV2.MetricPayload
+				body, _ := r.GetBody()
+				defer body.Close()
+				data, _ := io.ReadAll(body)
+				json.Unmarshal(data, &payload)
+
+				for _, metric := range payload.Series {
+					require.Equal(t, 1, len(metric.Points), "metric series should have only 1 metric")
+					collectedMetrics[metric.Metric] = *metric.Points[0].Value
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ops["api-compress"] = "false" // Turn off compression so that we get easier calculations for sizing
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	require.NoError(t, err)
+	ddSink.tr = &mock.Tr{
+		TranslateFunc: func(domain, metric string) string {
+			return fmt.Sprintf("%s.%s", domain, metric)
+		},
+	}
+
+	// Create a retry sink and wrap the datadog sink
+	retrySink := NewRetry(RetryArgs{
+		MonitorId:  "m1",
+		Sink:       ddSink,
+		BufferSize: 4,
+	})
+
+	blipMetricsFirstBatch := getBlipCounterMetrics(metricCount, 10.0, true)
+
+	// Don't fail on the first attempt. We want to get the first set of
+	// data points established for the delta calculations
+	failChan <- false
+
+	// Running retrySink.Send will block on the submission, so handle
+	// waiting for the signal on the channel in the background
+	go func() {
+		<-enteredChan
+	}()
+	err = retrySink.Send(context.Background(), blipMetricsFirstBatch)
+	require.NoError(t, err)
+	// only half the metrics with Delta counter values should be sent
+	require.Equal(t, metricCount/2, len(collectedMetrics))
+
+	// reset collected
+	collectedMetrics = map[string]float64{}
+	blipMetricsSecondBatch := getBlipCounterMetrics(metricCount, 20.0, true)
+
+	// Simulate a metric failing to send, but wait until we have the
+	// next metric queued to allow the failure to happen. This will
+	// cause the retry queue to run the next iteration of the retry loop,
+	// which will pull the *third* metric batch rather than trying the second again.
+	// The order will be:
+	// Try Second Batch -> FAIL
+	// Try Third Batch -> SUCCESS
+	// Try Second Batch (2nd attempt) -> SUCCESS
+
+	// Launch the retrySink.Send in a goroutine as it will block otherwise
+	go func() {
+		err = retrySink.Send(context.Background(), blipMetricsSecondBatch)
+		require.NoError(t, err)
+	}()
+
+	// Wait to confirm that the second attempt has started the submission.
+	// We confirm that the goroutine has started so that the third submission
+	// will not block, as retrySink will detect that another routine is already
+	// processing and simply queue the third batch.
+	<-enteredChan
+
+	// Simulate a third metric coming in and queuing
+	blipMetricsThirdBatch := getBlipCounterMetrics(metricCount, 40.0, true)
+	err = retrySink.Send(context.Background(), blipMetricsThirdBatch)
+
+	// Fail the second batch
+	failChan <- true
+	// Confirm the third batch has entered submission
+	<-enteredChan
+	// Allow the third batch to process as expected
+	failChan <- false
+
+	// Confirm the second batch (2nd attempt) has entered submission
+	<-enteredChan
+	// Allow the second batch to process as expected
+	failChan <- false
+
+	// Wait for all batches to finish
+	wg.Wait()
+
+	// With the delta calculation failing we expect the most recent
+	// collected metrics to match the second batch exactly, as
+	// the out of order processing will result in negative deltas.
+	// Negative deltas don't get sent and instead the raw values from the
+	// batch are submitted.
+	expectedMetrics := map[string]float64{}
+	for _, metric := range blipMetricsSecondBatch.Values["testdomain"] {
+		name := fmt.Sprintf("testdomain.%s", metric.Name)
+		expectedMetrics[name] = metric.Value
+	}
+
+	require.Equal(t, metricCount, len(collectedMetrics))
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+// This test demonstrates how the Delta sink can prevent issues with the Retry
+// sink. The Delta sink replaces CUMULATIVE_COUNTER values in the metric batch
+// with DELTA_COUNTER values, before sending the modified batch to the Retry sink.
+// This causes any retires to use the already calculated delta values instead of
+// causing a recaculation that uses bad prior metric values.
+func TestDatadogCounterMetricsDeltaCalculation_RetrySinkDeltaSink(t *testing.T) {
+	metricCount := 50
+	collectedMetrics := map[string]float64{}
+
+	// Create controls for handling the timing
+	// of goroutines so we can coordinate the scenario
+	var wg sync.WaitGroup
+	failChan := make(chan bool, 2)
+	enteredChan := make(chan struct{})
+
+	httpClient := &http.Client{
+		Transport: &mock.Transport{
+			RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+				// Track when the submission is running
+				wg.Add(1)
+				defer wg.Done()
+
+				// Wait for the caller to confirm that it knows that
+				// the submission has started
+				enteredChan <- struct{}{}
+
+				// Determine if the submission should fail or not
+				shouldFail := <-failChan
+				if shouldFail {
+					return nil, fmt.Errorf("Test Failure")
+				}
+
+				var payload datadogV2.MetricPayload
+				body, _ := r.GetBody()
+				defer body.Close()
+				data, _ := io.ReadAll(body)
+				json.Unmarshal(data, &payload)
+
+				for _, metric := range payload.Series {
+					require.Equal(t, 1, len(metric.Points), "metric series should have only 1 metric")
+					collectedMetrics[metric.Metric] = *metric.Points[0].Value
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	}
+
+	ops := defaultOps()
+	ops["api-compress"] = "false" // Turn off compression so that we get easier calculations for sizing
+	ddSink, err := NewDatadog("testmonitor", ops, map[string]string{}, httpClient)
+	require.NoError(t, err)
+	ddSink.tr = &mock.Tr{
+		TranslateFunc: func(domain, metric string) string {
+			return fmt.Sprintf("%s.%s", domain, metric)
+		},
+	}
+
+	// Create a retry sink and wrap the datadog sink
+	retrySink := NewRetry(RetryArgs{
+		MonitorId:  "m1",
+		Sink:       ddSink,
+		BufferSize: 4,
+	})
+
+	// Wrap the retry sink in a delta sink
+	deltaSink := NewDelta(retrySink)
+
+	blipMetricsFirstBatch := getBlipCounterMetrics(metricCount, 10.0, true)
+
+	// Don't fail on the first attempt. We want to get the first set of
+	// data points established for the delta calculations
+	failChan <- false
+
+	// Running deltaSink.Send will block on the submission, so handle
+	// waiting for the signal on the channel in the background
+	go func() {
+		<-enteredChan
+	}()
+	err = deltaSink.Send(context.Background(), blipMetricsFirstBatch)
+	require.NoError(t, err)
+	// only half the metrics with Delta counter values should be sent
+	require.Equal(t, metricCount/2, len(collectedMetrics))
+
+	// reset collected
+	collectedMetrics = map[string]float64{}
+	blipMetricsSecondBatch := getBlipCounterMetrics(metricCount, 20.0, true)
+
+	// Simulate a metric failing to send, but wait until we have the
+	// next metric queued to allow the failure to happen. This will
+	// cause the retry queue to run the next iteration of the retry loop,
+	// which will pull the *third* metric batch rather than trying the second again.
+	// The order will be:
+	// Try Second Batch -> FAIL
+	// Try Third Batch -> SUCCESS
+	// Try Second Batch (2nd attempt) -> SUCCESS
+
+	// Launch the deltaSink.Send in a goroutine as it will block otherwise
+	go func() {
+		err = deltaSink.Send(context.Background(), blipMetricsSecondBatch)
+		require.NoError(t, err)
+	}()
+
+	// Wait to confirm that the second attempt has started the submission.
+	// We confirm that the goroutine has started so that the third submission
+	// will not block, as retrySink inside the Delta sink will detect that
+	// another routine is already processing and simply queue the third batch.
+	<-enteredChan
+
+	// Simulate a third metric coming in and queuing
+	blipMetricsThirdBatch := getBlipCounterMetrics(metricCount, 40.0, true)
+	err = deltaSink.Send(context.Background(), blipMetricsThirdBatch)
+
+	// Fail the second batch
+	failChan <- true
+	// Confirm the third batch has entered submission
+	<-enteredChan
+	// Allow the third batch to process as expected
+	failChan <- false
+
+	// Confirm the second batch (2nd attempt) has entered submission
+	<-enteredChan
+	// Allow the second batch to process as expected
+	failChan <- false
+
+	// Wait for all batches to finish
+	wg.Wait()
+
+	// Since the second batch was processed last we expect that the collected metrics
+	// will match the delta values between the second batch and the first batch
+	// once the second batch was successfully submitted.
+	expectedMetrics := map[string]float64{}
+	expectedMetrics = getExpectedMetrics(blipMetricsSecondBatch, blipMetricsFirstBatch)
+	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
+		t.Fatal(diff)
+	}
+
+	require.Equal(t, metricCount, len(collectedMetrics))
 	if diff := deep.Equal(expectedMetrics, collectedMetrics); diff != nil {
 		t.Fatal(diff)
 	}

--- a/sink/delta.go
+++ b/sink/delta.go
@@ -1,0 +1,145 @@
+// Copyright 2023 Block, Inc.
+
+package sink
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cashapp/blip"
+)
+
+// The Delta sink calculates DELTER_COUNTER metrics from CUMULATIVE_COUNTER metrics. It acts as a transform,
+// removing CUMULATIVE_COUNTER metrics and replacing them with DELTER_COUNTER values. This can be used
+// to wrap sinks that expect counters to be submitted as the number/count of observations in the
+// sampling interval rather than a cumulative total.
+//
+// The Delta sink is perferable to peforming delta calculations in the wrapped sink
+// as the presence of a Retry sink can cause metrics to be sent to wrapped sink out of order, which
+// can cause incorrect metric values to be submitted then delta calculations are performed.
+// The Delta sink should never be wrapped inside of a Retry sink to prevent this.
+type Delta struct {
+	sink     blip.Sink
+	counters map[string]float64 // holds last value of the counter so deltas can be calculated
+}
+
+var _ blip.Sink = &Delta{}
+
+func NewDelta(sink blip.Sink) *Delta {
+	if sink == nil {
+		panic("sink is nil; value required")
+	}
+	if _, ok := sink.(*Delta); ok {
+		panic("sink cannot be a Delta sink.")
+	}
+
+	return &Delta{
+		sink:     sink,
+		counters: make(map[string]float64),
+	}
+}
+
+func (d *Delta) Name() string {
+	return "delta"
+}
+
+// Calculates DELTA_COUNTER values from any CUMULATIVE_COUNTER values in
+// the passed metircs, and then replacees the CUMULATIVE_COUNTER values
+// with the new DELTA_COUNTER values. The updated metrics are forwarded
+// to the next sink.
+//
+// This is safe to call from multiple goroutines.
+func (d *Delta) Send(ctx context.Context, metrics *blip.Metrics) error {
+	newValues := make(map[string][]blip.MetricValue)
+	hasNewValues := false
+
+	for key, collection := range metrics.Values {
+		valueList := make([]blip.MetricValue, 0, len(collection))
+		hasDelta := false
+
+		for _, value := range collection {
+			// Calculate a DELTA for any cumulative counters
+			switch value.Type {
+			case blip.CUMULATIVE_COUNTER:
+				hasDelta = true
+				metricValue := value.Value
+				metricId := d.metricID(value.Name, value.Group)
+
+				val, ok := d.counters[metricId]
+				if !ok {
+					// If we don't have a prior data point then we should
+					// not calculate a delta and just remove the point.
+					d.counters[metricId] = value.Value
+					continue
+				}
+
+				delta := value.Value - val
+				d.counters[metricId] = value.Value
+				if delta >= 0 {
+					metricValue = delta
+				} else {
+					blip.Debug("found negative delta for: %s (can happen due to restart), sending the potentially partial metric value", value.Name)
+				}
+
+				value.Value = metricValue
+				value.Type = blip.DELTA_COUNTER
+				break
+
+			default:
+				break
+			}
+
+			valueList = append(valueList, value)
+		}
+
+		if hasDelta {
+			newValues[key] = valueList
+			hasNewValues = true
+		} else {
+			// If we didn't have to calculate any deltas we can just reuse the existing array
+			newValues[key] = collection
+		}
+	}
+
+	if !hasNewValues {
+		// If we didn't have to calculate any deltas then we should
+		// just submit the original metrics
+		return d.sink.Send(ctx, metrics)
+	}
+
+	return d.sink.Send(ctx, &blip.Metrics{
+		Begin:     metrics.Begin,
+		End:       metrics.End,
+		MonitorId: metrics.MonitorId,
+		Plan:      metrics.Plan,
+		Level:     metrics.Level,
+		State:     metrics.State,
+		Values:    newValues,
+	})
+}
+
+// metricID returns the metric name concatenated with sorted group keys.
+// For example, if the metric name is "foo" and the group keys are "a" and "b",
+// it returns "fooab". This is used to calculate delta counter values in Send.
+func (s *Delta) metricID(name string, groups map[string]string) string {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+
+	// sort by keys
+	sort.Strings(keys)
+
+	var values []string
+	// collect values by sorted keys
+	for _, k := range keys {
+		values = append(values, groups[k])
+	}
+
+	var key string
+	key += name
+	key += strings.Join(values, "")
+
+	return key
+}

--- a/sink/delta_test.go
+++ b/sink/delta_test.go
@@ -1,0 +1,251 @@
+package sink
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/test/mock"
+	"github.com/go-test/deep"
+)
+
+func getNoChangesValues() []blip.MetricValue {
+	return []blip.MetricValue{
+		{
+			Name:  "gauge",
+			Value: 1.0,
+			Type:  blip.GAUGE,
+		},
+		{
+			Name:  "delta",
+			Value: 1.0,
+			Type:  blip.DELTA_COUNTER,
+		},
+	}
+}
+
+func getChangesValues() []blip.MetricValue {
+	return []blip.MetricValue{
+		{
+			Name:  "counter",
+			Value: 1.0,
+			Type:  blip.CUMULATIVE_COUNTER,
+			Group: map[string]string{
+				"a": "1",
+			},
+		},
+		{
+			Name:  "counter",
+			Value: 1.0,
+			Type:  blip.CUMULATIVE_COUNTER,
+			Group: map[string]string{
+				"a": "2",
+			},
+		},
+		{
+			Name:  "delta",
+			Value: 1.0,
+			Type:  blip.DELTA_COUNTER,
+		},
+	}
+}
+
+func TestDeltaSink(t *testing.T) {
+	var returnedResults *blip.Metrics
+	mockSink := &mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			returnedResults = m
+			return nil
+		},
+	}
+
+	noChangesValues := getNoChangesValues()
+	metrics := &blip.Metrics{
+		Begin:     time.Now().Add(-1 * time.Hour),
+		End:       time.Now(),
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"nochanges": noChangesValues,
+			"changes":   getChangesValues(),
+		},
+	}
+
+	deltaSink := NewDelta(mockSink)
+	err := deltaSink.Send(context.Background(), metrics)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// If we had to perform delta calculations then we will get a pointer to a new
+	// set of metrics.
+	if metrics == returnedResults {
+		t.Error("Expected returnedResults and metrics to be different pointers but they matched")
+	}
+
+	// The first time we submit cumulative metrics we should not expect to see them
+	// in the output as we didn't have enough data points to calculate deltas. The
+	// only deltas should be those submitted as delta values.
+	expectedMetrics := &blip.Metrics{
+		Begin:     metrics.Begin,
+		End:       metrics.End,
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"nochanges": noChangesValues,
+			"changes": {
+				{
+					Name:  "delta",
+					Value: 1.0,
+					Type:  blip.DELTA_COUNTER,
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(expectedMetrics, returnedResults); diff != nil {
+		t.Error(diff)
+	}
+
+	// Update and send new metrics
+	// The cumulative counters should have their values increased
+	// so we get valid deltas.
+	changesValues := getChangesValues()
+	changesValues[0].Value = 2.0
+	changesValues[1].Value = 3.0
+
+	metrics = &blip.Metrics{
+		Begin:     time.Now().Add(-1 * time.Hour),
+		End:       time.Now(),
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"nochanges": noChangesValues,
+			"changes":   changesValues,
+		},
+	}
+
+	err = deltaSink.Send(context.Background(), metrics)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if metrics == returnedResults {
+		t.Error("Expected returnedResults and metrics to be different pointers but they matched")
+	}
+
+	// We should see the newly calculated delta values now that we had a prior run
+	expectedMetrics = &blip.Metrics{
+		Begin:     metrics.Begin,
+		End:       metrics.End,
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"nochanges": noChangesValues,
+			"changes": {
+				{
+					Name:  "counter",
+					Value: 1.0,
+					Type:  blip.DELTA_COUNTER,
+					Group: map[string]string{
+						"a": "1",
+					},
+				},
+				{
+					Name:  "counter",
+					Value: 2.0,
+					Type:  blip.DELTA_COUNTER,
+					Group: map[string]string{
+						"a": "2",
+					},
+				},
+				{
+					Name:  "delta",
+					Value: 1.0,
+					Type:  blip.DELTA_COUNTER,
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(expectedMetrics, returnedResults); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDeltaSink_Passthrough(t *testing.T) {
+	var returnedResults *blip.Metrics
+	mockSink := &mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			returnedResults = m
+			return nil
+		},
+	}
+
+	metrics := &blip.Metrics{
+		Begin:     time.Now().Add(-1 * time.Hour),
+		End:       time.Now(),
+		MonitorId: "testmonitor",
+		Plan:      "testplan",
+		Level:     "testlevel",
+		State:     "teststate",
+		Values: map[string][]blip.MetricValue{
+			"nochanges": getNoChangesValues(),
+		},
+	}
+
+	deltaSink := NewDelta(mockSink)
+	err := deltaSink.Send(context.Background(), metrics)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// If the metrics don't contain any cumulative metrics then we should
+	// just get the same metrics pointer returned as no transformations needed to happen.
+	if metrics != returnedResults {
+		t.Error("Expected returnedResults and metrics to be the same pointers but they are different")
+	}
+}
+
+func TestDelta_NoDeltaSink(t *testing.T) {
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			return nil
+		},
+	}
+
+	deltaSink := NewDelta(mockSink)
+
+	func() {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Error("Expected an error but didn't get one")
+			}
+		}()
+
+		// Create the Retry sink with a Delta sink, which isn't allowed.
+		NewDelta(deltaSink)
+	}()
+}
+
+func TestDelta_NoNilSink(t *testing.T) {
+	func() {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Error("Expected an error but didn't get one")
+			}
+		}()
+
+		// Create the Retry sink with a Delta sink, which isn't allowed.
+		NewDelta(nil)
+	}()
+}

--- a/sink/factory.go
+++ b/sink/factory.go
@@ -167,6 +167,13 @@ func (f *factory) Make(args blip.SinkFactoryArgs) (blip.Sink, error) {
 		return nil, err
 	}
 
-	// Return built-in sink as Retry, which implements blip.Sink
-	return NewRetry(retryArgs), nil
+	// Wrap the sink as needed. All sinks should be wrapped with the
+	// built-in Retry sink, but some need to calculate delta
+	// versions for counters, which should wrap the Retry sink
+	switch args.SinkName {
+	case "datadog":
+		return NewDelta(NewRetry(retryArgs)), nil
+	default:
+		return NewRetry(retryArgs), nil
+	}
 }

--- a/sink/retry.go
+++ b/sink/retry.go
@@ -59,6 +59,10 @@ func NewRetry(args RetryArgs) *Retry {
 		panic("RetryArgs.Sink is nil; value required")
 	}
 
+	if _, ok := args.Sink.(*Delta); ok {
+		panic("RetryArgs.Sink cannot be a Delta sink.")
+	}
+
 	// Set defaults
 	if args.BufferSize == 0 {
 		args.BufferSize = DEFAULT_RETRY_BUFFER_SIZE

--- a/sink/retry_test.go
+++ b/sink/retry_test.go
@@ -196,3 +196,28 @@ func TestRetryPopMiddle(t *testing.T) {
 	expect = []string{"2", "3", "", ""}
 	assert.Equal(t, expect, got)
 }
+
+func TestRetry_NoDeltaSink(t *testing.T) {
+	mockSink := mock.Sink{
+		SendFunc: func(ctx context.Context, m *blip.Metrics) error {
+			return nil
+		},
+	}
+
+	deltaSink := NewDelta(mockSink)
+
+	func() {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Error("Expected an error but didn't get one")
+			}
+		}()
+
+		// Create the Retry sink with a Delta sink, which isn't allowed.
+		NewRetry(RetryArgs{
+			MonitorId:  "m1",
+			Sink:       deltaSink,
+			BufferSize: 4,
+		})
+	}()
+}

--- a/sink/signalfx.go
+++ b/sink/signalfx.go
@@ -5,8 +5,8 @@ package sink
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -41,7 +41,7 @@ func NewSignalFx(monitorId string, opts, tags map[string]string, httpClient *htt
 	for k, v := range opts {
 		switch k {
 		case "auth-token-file":
-			bytes, err := ioutil.ReadFile(v)
+			bytes, err := os.ReadFile(v)
 			if err != nil {
 				return nil, err
 			} else {

--- a/test/mock/metrics.go
+++ b/test/mock/metrics.go
@@ -28,9 +28,13 @@ var _ blip.Collector = MetricsCollector{}
 type MetricsCollector struct {
 	PrepareFunc func(ctx context.Context, plan blip.Plan) (func(), error)
 	CollectFunc func(ctx context.Context, levelName string) ([]blip.MetricValue, error)
+	DomainFunc  func() string
 }
 
 func (c MetricsCollector) Domain() string {
+	if c.DomainFunc != nil {
+		return c.DomainFunc()
+	}
 	return "test"
 }
 

--- a/test/plans/lpc_2_domains.yaml
+++ b/test/plans/lpc_2_domains.yaml
@@ -1,0 +1,15 @@
+---
+level_1:
+  freq: 1s
+  collect:
+    test:
+      metrics:
+        - m1
+      options: {}  # Needed so tests don't get a nil map
+level_2:
+  freq: 5s
+  collect:
+    long:
+      metrics:
+        - m2
+      options: {}


### PR DESCRIPTION
Ian's original PR works around engine v1 problems using fully asynchronous metrics collections from collectors to sinks. Engine v2 will scope this down to preserve synchronous calls were possible, so I'll modify this code after merging. But I wanted to start with this code because it also has various code fixes we need.