### PR TITLE
Release v1.1.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,5 @@ User-submitted PRs for older versions are welcomed if they security-specific fix
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+| 1.1.x   | Yes |
+| 1.0.x   | No  |

--- a/blip.go
+++ b/blip.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Block, Inc.
+// Copyright 2024 Block, Inc.
 
 // Package blip provides high-level data structs and const for integrating with Blip.
 package blip
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-const VERSION = "1.0.2"
+const VERSION = "1.1.0"
 
 var SHA = ""
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-ini/ini v1.64.0
 	github.com/go-mysql/errors v0.0.0-20180603193453-03314bea68e0
 	github.com/go-mysql/hotswap-dsn-driver v1.0.1
-	github.com/go-sql-driver/mysql v1.7.1
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-test/deep v1.0.8
 	github.com/golang/snappy v0.0.4
 	github.com/hashicorp/go-version v1.3.0
@@ -30,6 +30,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/DataDog/zstd v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-api-client-go/v2 v2.2.0 h1:woWe+XBcYt29g1SJs+zbgwYPfyATb+gxeA2pKqUu02Y=
 github.com/DataDog/datadog-api-client-go/v2 v2.2.0/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
@@ -83,8 +85,8 @@ github.com/go-mysql/errors v0.0.0-20180603193453-03314bea68e0/go.mod h1:ZH8V0509
 github.com/go-mysql/hotswap-dsn-driver v1.0.1 h1:Ssm8Gqk3DLkZSyEuFOh1g1ReKBwhLiuYF0Qy4eb0zvo=
 github.com/go-mysql/hotswap-dsn-driver v1.0.1/go.mod h1:YjeTwHrsEcFpzJDfOFO95lPZACK/TVo/xtu4Qgi2uC8=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
-github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=


### PR DESCRIPTION
* Bump version to v1.1.0
* Update SECURITY.md
* Update Go MySQL driver

[Docs](https://cashapp.github.io/blip/) have already been updated and published.