### PR TITLE
add debug API endpoint and signal listener

### DIFF
--- a/docs/content/api/blip.md
+++ b/docs/content/api/blip.md
@@ -60,4 +60,14 @@ Returns the Blip version (same as [`--version`]({{< ref "/config/blip#--version"
 "v1.0.75"
 ```
 
-Response encoding is text (string).
+## GET /debug
+
+Toggles debug logging.
+
+*Response*
+
+```json
+{"debugging":true}
+```
+
+

--- a/docs/content/config/blip.md
+++ b/docs/content/config/blip.md
@@ -55,6 +55,8 @@ In this case, Blip tries to auto-detect a local MySQL instance, which is useful 
 
 Print debug to STDERR.
 
+You can also toggle debug logging by sending a request to the `/debug` [API endpoint]({{< ref "/api" >}}) or by sending the `SIGUSR1` signal to the Blip process.
+
 ### `--help`
 
 Print help and exit.

--- a/docs/content/config/logging.md
+++ b/docs/content/config/logging.md
@@ -7,6 +7,7 @@ Start `blip` with the [`--log`]({{< ref "blip#--log" >}}) option to print info e
 
 <p class="note">
 <a href="blip#--debug">Debug</a> info is printed to <code>STDERR</code>.
+You can also toggle debug logging by sending a request to the `/debug` [API endpoint]({{< ref "/api" >}}) or by sending the `SIGUSR1` signal to the Blip process.
 </p>
 
 This is _pseudo-logging_ because there is no traditional log printing, only events that are printed by default.

--- a/server/api.go
+++ b/server/api.go
@@ -50,6 +50,8 @@ func NewAPI(cfg blip.Config, ml *monitor.Loader) *API {
 	mux.HandleFunc("/status", api.status)
 	mux.HandleFunc("/status/monitors", api.statusMonitors)
 
+	mux.HandleFunc("/debug", api.debug)
+
 	api.httpServer = &http.Server{
 		Addr:    cfg.API.Bind,
 		Handler: mux,
@@ -124,6 +126,12 @@ func (api *API) registered(w http.ResponseWriter, r *http.Request) {
 func (api *API) version(w http.ResponseWriter, r *http.Request) {
 	blip.Debug("%v", r)
 	w.Write([]byte(blip.VERSION))
+}
+
+func (api *API) debug(w http.ResponseWriter, r *http.Request) {
+	blip.Debug("%v", r)
+	blip.Debugging = !blip.Debugging
+	w.Write([]byte(fmt.Sprintf("Debugging: %t", blip.Debugging)))
 }
 
 // --------------------------------------------------------------------------

--- a/server/api.go
+++ b/server/api.go
@@ -125,13 +125,13 @@ func (api *API) registered(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) version(w http.ResponseWriter, r *http.Request) {
 	blip.Debug("%v", r)
-	w.Write([]byte(blip.VERSION))
+	json.NewEncoder(w).Encode(blip.VERSION)
 }
 
 func (api *API) debug(w http.ResponseWriter, r *http.Request) {
 	blip.Debug("%v", r)
 	blip.Debugging = !blip.Debugging
-	w.Write([]byte(fmt.Sprintf("Debugging: %t", blip.Debugging)))
+	json.NewEncoder(w).Encode(map[string]bool{"debugging": blip.Debugging})
 }
 
 // --------------------------------------------------------------------------

--- a/server/server.go
+++ b/server/server.go
@@ -263,7 +263,7 @@ func (s *Server) Run(stopChan, doneChan chan struct{}) error {
 	status.Blip(status.SERVER, "running since %s", blip.FormatTime(time.Now()))
 	signalChan := make(chan os.Signal)
 	defer close(signalChan)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINFO)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
 	for {
 		select {
 		case <-stopChan:
@@ -274,9 +274,9 @@ func (s *Server) Run(stopChan, doneChan chan struct{}) error {
 			case os.Interrupt, syscall.SIGTERM:
 				stopReason = "caught signal"
 				return nil
-			case syscall.SIGINFO:
+			case syscall.SIGUSR1:
 				blip.Debugging = !blip.Debugging
-				fmt.Fprintf(os.Stderr, "SIGINFO has set blip.Debugging to %t\n", blip.Debugging)
+				fmt.Fprintf(os.Stderr, "SIGUSR1 has set blip.Debugging to %t\n", blip.Debugging)
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -261,7 +261,7 @@ func (s *Server) Run(stopChan, doneChan chan struct{}) error {
 
 	// Run until caller closes stopChan or blip process catches a signal
 	status.Blip(status.SERVER, "running since %s", blip.FormatTime(time.Now()))
-	signalChan := make(chan os.Signal)
+	signalChan := make(chan os.Signal, 1)
 	defer close(signalChan)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
 	for {


### PR DESCRIPTION
This PR adds 2 things:

1. a new `/debug` API endpoint which toggles blip.Debugging. it returns a string telling you whether it's been enabled or disabled.
2. a signal listener on `SIGUSR1` that toggles blip.Debugging. this will write to stderr whether it's turned debugging on or off.

I figured it might be helpful to support both of these. In a k8s context, it might be more simple to send a signal to the process running in the container than to figure out where its API endpoint is listening.