### PR TITLE
Fix `sqlutil.INList`

### DIFF
--- a/dbconn/factory.go
+++ b/dbconn/factory.go
@@ -116,7 +116,7 @@ func (f factory) Make(cfg blip.ConfigMonitor) (*sql.DB, string, error) {
 	// ----------------------------------------------------------------------
 	// Load TLS
 
-	params := []string{"parseTime=true"}
+	params := []string{"parseTime=true", "interpolateParams=true"}
 
 	// Go says "either ServerName or InsecureSkipVerify must be specified".
 	// This is a pathological case: socket and TLS but no hostname to verify

--- a/dbconn/factory_test.go
+++ b/dbconn/factory_test.go
@@ -54,7 +54,7 @@ func TestConnect(t *testing.T) {
 	defer db.Close()
 
 	// Make returns a print-safe DSN: password ("test") replaced with "..."
-	expectDSN := fmt.Sprintf("%s:...@tcp(%s)/?parseTime=true", cfg.Username, cfg.Hostname)
+	expectDSN := fmt.Sprintf("%s:...@tcp(%s)/?interpolateParams=true&parseTime=true", cfg.Username, cfg.Hostname)
 	if dsn != expectDSN {
 		t.Errorf("got DSN '%s', expected '%s'", dsn, expectDSN)
 	}

--- a/metrics/size.database/query.go
+++ b/metrics/size.database/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cashapp/blip/sqlutil"
 )
 
-func DataSizeQuery(set map[string]string, def blip.CollectorHelp) (string, error) {
+func DataSizeQuery(set map[string]string, def blip.CollectorHelp) (string, []interface{}, error) {
 	cols := ""
 	groupBy := ""
 	if val := set[OPT_TOTAL]; val == "only" {
@@ -26,32 +26,42 @@ func DataSizeQuery(set map[string]string, def blip.CollectorHelp) (string, error
 		like = true
 	}
 
+	var params []interface{}
+
 	where := ""
 	if include := set[OPT_INCLUDE]; include != "" {
-		o := sqlutil.ObjectList(include, "'")
+		o := strings.Split(include, ",")
+		params = make([]interface{}, 0, len(o))
+
 		if like {
 			for i := range o {
-				o[i] = "table_schema LIKE " + o[i]
+				params = append(params, o[i])
+				o[i] = "table_schema LIKE ?"
 			}
 			where = strings.Join(o, " OR ")
 		} else {
-			where = fmt.Sprintf("table_schema IN (%s)", strings.Join(o, ","))
+			where = fmt.Sprintf("table_schema IN (%s)", sqlutil.PlaceholderList(len(o)))
+			params = sqlutil.ToInterfaceArray(o)
 		}
 	} else {
 		exclude := set[OPT_EXCLUDE]
 		if exclude == "" {
 			exclude = def.Options[OPT_EXCLUDE].Default
 		}
-		o := sqlutil.ObjectList(exclude, "'")
+		o := strings.Split(exclude, ",")
+		params = make([]interface{}, 0, len(o))
+
 		if like {
 			for i := range o {
-				o[i] = "table_schema NOT LIKE " + o[i]
+				params = append(params, o[i])
+				o[i] = "table_schema NOT LIKE ?"
 			}
 			where = strings.Join(o, " AND ")
 		} else {
-			where = fmt.Sprintf("table_schema NOT IN (%s)", strings.Join(o, ","))
+			where = fmt.Sprintf("table_schema NOT IN (%s)", sqlutil.PlaceholderList(len(o)))
+			params = sqlutil.ToInterfaceArray(o)
 		}
 	}
 
-	return "SELECT " + cols + " FROM information_schema.tables WHERE " + where + groupBy, nil
+	return "SELECT " + cols + " FROM information_schema.tables WHERE " + where + groupBy, params, nil
 }

--- a/metrics/size.table/query.go
+++ b/metrics/size.table/query.go
@@ -3,38 +3,42 @@
 package sizetable
 
 import (
-	"fmt"
 	"strings"
 )
 
-func TableSizeQuery(set map[string]string) (string, error) {
+func TableSizeQuery(set map[string]string) (string, []interface{}, error) {
 	query := "SELECT table_schema AS db, table_name as tbl, COALESCE(data_length + index_length, 0) AS tbl_size_bytes FROM information_schema.TABLES"
 	var where string
+	var params []interface{}
 	if include := set[OPT_INCLUDE]; include != "" {
-		where = setWhere(strings.Split(set[OPT_INCLUDE], ","), true)
+		where, params = setWhere(strings.Split(set[OPT_INCLUDE], ","), true)
 	} else {
-		where = setWhere(strings.Split(set[OPT_EXCLUDE], ","), false)
+		where, params = setWhere(strings.Split(set[OPT_EXCLUDE], ","), false)
 	}
-	return query + where, nil
+	return query + where, params, nil
 }
 
-func setWhere(tables []string, isInclude bool) string {
+func setWhere(tables []string, isInclude bool) (string, []interface{}) {
 	where := " WHERE "
 	if !isInclude {
 		where = where + "NOT "
 	}
+	var params []interface{} = make([]interface{}, 0)
 	for i, excludeTable := range tables {
 		if strings.Contains(excludeTable, ".") {
 			dbAndTable := strings.Split(excludeTable, ".")
 			db := dbAndTable[0]
 			table := dbAndTable[1]
 			if table == "*" {
-				where = where + fmt.Sprintf("(table_schema = '%s')", db)
+				where = where + "(table_schema = ?)"
+				params = append(params, db)
 			} else {
-				where = where + fmt.Sprintf("(table_schema = '%s' AND table_name = '%s')", db, table)
+				where = where + "(table_schema = ? AND table_name = ?)"
+				params = append(params, db, table)
 			}
 		} else {
-			where = where + fmt.Sprintf("(table_name = '%s')", excludeTable)
+			where = where + "(table_name = ?)"
+			params = append(params, excludeTable)
 		}
 		if i != (len(tables) - 1) {
 			if isInclude {
@@ -44,5 +48,5 @@ func setWhere(tables []string, isInclude bool) string {
 			}
 		}
 	}
-	return where
+	return where, params
 }

--- a/metrics/size.table/query_test.go
+++ b/metrics/size.table/query_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	sizetable "github.com/cashapp/blip/metrics/size.table"
+	"github.com/go-test/deep"
 )
 
 func TestTableSizeQuery(t *testing.T) {
@@ -13,24 +14,35 @@ func TestTableSizeQuery(t *testing.T) {
 	opts := map[string]string{
 		sizetable.OPT_EXCLUDE: "mysql.*,information_schema.*,performance_schema.*,sys.*",
 	}
-	got, err := sizetable.TableSizeQuery(opts)
-	expect := "SELECT table_schema AS db, table_name as tbl, COALESCE(data_length + index_length, 0) AS tbl_size_bytes FROM information_schema.TABLES WHERE NOT (table_schema = 'mysql') AND NOT (table_schema = 'information_schema') AND NOT (table_schema = 'performance_schema') AND NOT (table_schema = 'sys')"
+	got, params, err := sizetable.TableSizeQuery(opts)
+	expect := "SELECT table_schema AS db, table_name as tbl, COALESCE(data_length + index_length, 0) AS tbl_size_bytes FROM information_schema.TABLES WHERE NOT (table_schema = ?) AND NOT (table_schema = ?) AND NOT (table_schema = ?) AND NOT (table_schema = ?)"
 	if err != nil {
 		t.Error(err)
 	}
 	if got != expect {
 		t.Errorf("got:\n%s\nexpect:\n%s\n", got, expect)
 	}
+
+	expectedParams := []interface{}{"mysql", "information_schema", "performance_schema", "sys"}
+	if diff := deep.Equal(params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
 	// Exclude schemas, mysql, and sys
 	opts = map[string]string{
 		sizetable.OPT_INCLUDE: "test_table,sys.*,information_schema.XTRADB_ZIP_DICT",
 	}
-	got, err = sizetable.TableSizeQuery(opts)
-	expect = "SELECT table_schema AS db, table_name as tbl, COALESCE(data_length + index_length, 0) AS tbl_size_bytes FROM information_schema.TABLES WHERE (table_name = 'test_table') OR (table_schema = 'sys') OR (table_schema = 'information_schema' AND table_name = 'XTRADB_ZIP_DICT')"
+	got, params, err = sizetable.TableSizeQuery(opts)
+	expect = "SELECT table_schema AS db, table_name as tbl, COALESCE(data_length + index_length, 0) AS tbl_size_bytes FROM information_schema.TABLES WHERE (table_name = ?) OR (table_schema = ?) OR (table_schema = ? AND table_name = ?)"
 	if err != nil {
 		t.Error(err)
 	}
 	if got != expect {
 		t.Errorf("got:\n%s\nexpect:\n%s\n", got, expect)
+	}
+
+	expectedParams = []interface{}{"test_table", "sys", "information_schema", "XTRADB_ZIP_DICT"}
+	if diff := deep.Equal(params, expectedParams); diff != nil {
+		t.Error(diff)
 	}
 }

--- a/metrics/wait.io.table/query_test.go
+++ b/metrics/wait.io.table/query_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	waitiotable "github.com/cashapp/blip/metrics/wait.io.table"
+	"github.com/go-test/deep"
 )
 
 func TestTableIoQuery(t *testing.T) {
@@ -20,20 +21,31 @@ func TestTableIoQuery(t *testing.T) {
 		"count_insert",
 	}
 
-	got := waitiotable.TableIoWaitQuery(opts, metrics)
-	expect := "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_fetch, count_insert FROM performance_schema.table_io_waits_summary_by_table WHERE NOT (OBJECT_SCHEMA = 'mysql') AND NOT (OBJECT_SCHEMA = 'information_schema') AND NOT (OBJECT_SCHEMA = 'performance_schema') AND NOT (OBJECT_SCHEMA = 'sys')"
+	got, params := waitiotable.TableIoWaitQuery(opts, metrics)
+	expect := "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_fetch, count_insert FROM performance_schema.table_io_waits_summary_by_table WHERE NOT (OBJECT_SCHEMA = ?) AND NOT (OBJECT_SCHEMA = ?) AND NOT (OBJECT_SCHEMA = ?) AND NOT (OBJECT_SCHEMA = ?)"
 	if got != expect {
 		t.Errorf("got:\n%s\nexpect:\n%s\n", got, expect)
 	}
+
+	expectedParams := []interface{}{"mysql", "information_schema", "performance_schema", "sys"}
+	if diff := deep.Equal(params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
 	// Exclude schemas, mysql, and sys
 	opts = map[string]string{
 		waitiotable.OPT_INCLUDE: "test_table,sys.*,information_schema.XTRADB_ZIP_DICT",
 		waitiotable.OPT_ALL:     "no",
 	}
-	got = waitiotable.TableIoWaitQuery(opts, metrics)
-	expect = "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_fetch, count_insert FROM performance_schema.table_io_waits_summary_by_table WHERE (OBJECT_NAME = 'test_table') OR (OBJECT_SCHEMA = 'sys') OR (OBJECT_SCHEMA = 'information_schema' AND OBJECT_NAME = 'XTRADB_ZIP_DICT')"
+	got, params = waitiotable.TableIoWaitQuery(opts, metrics)
+	expect = "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_fetch, count_insert FROM performance_schema.table_io_waits_summary_by_table WHERE (OBJECT_NAME = ?) OR (OBJECT_SCHEMA = ?) OR (OBJECT_SCHEMA = ? AND OBJECT_NAME = ?)"
 	if got != expect {
 		t.Errorf("got:\n%s\nexpect:\n%s\n", got, expect)
+	}
+
+	expectedParams = []interface{}{"test_table", "sys", "information_schema", "XTRADB_ZIP_DICT"}
+	if diff := deep.Equal(params, expectedParams); diff != nil {
+		t.Error(diff)
 	}
 
 	// Use the default columns
@@ -41,9 +53,14 @@ func TestTableIoQuery(t *testing.T) {
 		waitiotable.OPT_INCLUDE: "test_table,sys.*,information_schema.XTRADB_ZIP_DICT",
 		waitiotable.OPT_ALL:     "yes",
 	}
-	got = waitiotable.TableIoWaitQuery(opts, []string{})
-	expect = "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_star, sum_timer_wait, min_timer_wait, avg_timer_wait, max_timer_wait, count_read, sum_timer_read, min_timer_read, avg_timer_read, max_timer_read, count_write, sum_timer_write, min_timer_write, avg_timer_write, max_timer_write, count_fetch, sum_timer_fetch, min_timer_fetch, avg_timer_fetch, max_timer_fetch, count_insert, sum_timer_insert, min_timer_insert, avg_timer_insert, max_timer_insert, count_update, sum_timer_update, min_timer_update, avg_timer_update, max_timer_update, count_delete, sum_timer_delete, min_timer_delete, avg_timer_delete, max_timer_delete FROM performance_schema.table_io_waits_summary_by_table WHERE (OBJECT_NAME = 'test_table') OR (OBJECT_SCHEMA = 'sys') OR (OBJECT_SCHEMA = 'information_schema' AND OBJECT_NAME = 'XTRADB_ZIP_DICT')"
+	got, params = waitiotable.TableIoWaitQuery(opts, []string{})
+	expect = "SELECT OBJECT_SCHEMA, OBJECT_NAME, count_star, sum_timer_wait, min_timer_wait, avg_timer_wait, max_timer_wait, count_read, sum_timer_read, min_timer_read, avg_timer_read, max_timer_read, count_write, sum_timer_write, min_timer_write, avg_timer_write, max_timer_write, count_fetch, sum_timer_fetch, min_timer_fetch, avg_timer_fetch, max_timer_fetch, count_insert, sum_timer_insert, min_timer_insert, avg_timer_insert, max_timer_insert, count_update, sum_timer_update, min_timer_update, avg_timer_update, max_timer_update, count_delete, sum_timer_delete, min_timer_delete, avg_timer_delete, max_timer_delete FROM performance_schema.table_io_waits_summary_by_table WHERE (OBJECT_NAME = ?) OR (OBJECT_SCHEMA = ?) OR (OBJECT_SCHEMA = ? AND OBJECT_NAME = ?)"
 	if got != expect {
 		t.Errorf("got:\n%s\nexpect:\n%s\n", got, expect)
+	}
+
+	expectedParams = []interface{}{"test_table", "sys", "information_schema", "XTRADB_ZIP_DICT"}
+	if diff := deep.Equal(params, expectedParams); diff != nil {
+		t.Error(diff)
 	}
 }

--- a/metrics/wait.io.table/table.go
+++ b/metrics/wait.io.table/table.go
@@ -81,6 +81,7 @@ func init() {
 
 type tableOptions struct {
 	query             string
+	params            []interface{}
 	truncate          bool
 	truncateTimeout   time.Duration
 	stop              bool
@@ -182,7 +183,7 @@ LEVEL:
 			dom.Options[OPT_EXCLUDE] = OPT_EXCLUDE_DEFAULT
 		}
 
-		o.query = TableIoWaitQuery(dom.Options, dom.Metrics)
+		o.query, o.params = TableIoWaitQuery(dom.Options, dom.Metrics)
 
 		if truncate, ok := dom.Options[OPT_TRUNCATE_TABLE]; ok && truncate == "no" {
 			o.truncate = false
@@ -233,7 +234,7 @@ func (t *Table) Collect(ctx context.Context, levelName string) ([]blip.MetricVal
 		return nil, nil
 	}
 
-	rows, err := t.db.QueryContext(ctx, o.query)
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlutil/sqlutil.go
+++ b/sqlutil/sqlutil.go
@@ -43,12 +43,15 @@ func Float64(s string) (float64, bool) {
 	return 0, false // failed
 }
 
+// DEPRECATED: Use interpolated queries instead
 func CleanObjectName(o string) string {
 	o = strings.ReplaceAll(o, ";", "")
 	o = strings.ReplaceAll(o, "`", "")
 	return strings.TrimSpace(o) // must be last in case Replace make space
 }
 
+// DEPRECATED: Use strings.Split instead in conjunction with
+// interpolated queries.
 func ObjectList(csv string, quoteChar string) []string {
 	objs := strings.Split(csv, ",")
 	for i := range objs {
@@ -57,13 +60,37 @@ func ObjectList(csv string, quoteChar string) []string {
 	return objs
 }
 
+// PlaceholderList returns a string of ? placeholders separated by commas.
+func PlaceholderList(count int) string {
+	if count <= 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("?%s", strings.Repeat(", ?", count-1))
+}
+
+// ToInterfaceArray converts a list of any type to a list of interface{}.
+func ToInterfaceArray[T any](list []T) []interface{} {
+	if len(list) == 0 {
+		return []interface{}{}
+	}
+
+	result := make([]interface{}, 0, len(list))
+	for _, value := range list {
+		result = append(result, value)
+	}
+
+	return result
+}
+
+// DEPRECATED: Use interpolated queries instead
 func INList(objs []string, quoteChar string) string {
 	if len(objs) == 0 {
 		return ""
 	}
 	in := quoteChar + CleanObjectName(objs[0]) + quoteChar
 	for i := range objs[1:] {
-		in += "," + quoteChar + CleanObjectName(objs[i]) + quoteChar
+		in += "," + quoteChar + CleanObjectName(objs[i+1]) + quoteChar
 	}
 	return in
 }

--- a/sqlutil/sqlutil_test.go
+++ b/sqlutil/sqlutil_test.go
@@ -27,3 +27,13 @@ func TestFloat64(t *testing.T) {
 		}
 	}
 }
+
+func TestInList(t *testing.T) {
+	values := []string{"bleh;", "`something`"}
+	result := INList(values, "'")
+	expected := "'bleh','something'"
+
+	if expected != result {
+		t.Errorf("INList(%v, \"'\"): got %s, expected %s", values, result, expected)
+	}
+}

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -30,7 +30,7 @@ func Connection(distroVersion string) (string, *sql.DB, error) {
 		return "", nil, fmt.Errorf("invalid distro-version: %s (see dockerPorts in test/mysql.go)", distroVersion)
 	}
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/?parseTime=true",
+		"%s:%s@tcp(%s:%s)/?parseTime=true&interpolateParams=true",
 		"root",
 		"test",
 		"127.0.0.1",


### PR DESCRIPTION
`sqlutil.INList` repeats the first value of the list and leaves the last value off the resulting string. Fixed this bug and replaced uses of unescaped `IN` list creation with calls to `sqlutil.INList` where appropriate.

Adjusted metrics and heartbeat to use driver-level parameter interpolation instead of custom escaping, deprecating several function in `sqlutil`. Removed the use of `sqlutil.INList` in existing blip code but marked as deprecated.