### PR TITLE
Force Order for Query Latency

### DIFF
--- a/metrics/query.response-time/response_time.go
+++ b/metrics/query.response-time/response_time.go
@@ -175,7 +175,7 @@ LEVEL:
 		for i := range p {
 			config.percentiles[i] = percentile{
 				formatted: p[i].Name,
-				query:     BASE_QUERY + fmt.Sprintf(" WHERE bucket_quantile >= %f ORDER BY bucket_quantile LIMIT 1", p[i].Value),
+				query:     BASE_QUERY + fmt.Sprintf(" WHERE bucket_quantile >= %f ORDER BY bucket_number LIMIT 1", p[i].Value),
 			}
 		}
 


### PR DESCRIPTION
`query.response-time` relies on the ordering of results based on `bucket_quantile` but in some cases there are multiple rows with the same value for `bucket_quantile`. This results in undefined behavior as we don't know which of the rows returned will be chosen for the `LIMIT 1`. Usually the results are ordered by the natural order of the table (e.g. `bucket_number`) which produces expected behavior but occasionaly this isn't the case and anomalous values are returned as the latency. Adding an explicit ordering on `bucket_number` in addition to `bucket_quantile` should resolve this issue.