### PR TITLE
Signal Channel Bugfix

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -264,6 +264,7 @@ func (s *Server) Run(stopChan, doneChan chan struct{}) error {
 	signalChan := make(chan os.Signal, 1)
 	defer close(signalChan)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
+	defer signal.Stop(signalChan)
 	for {
 		select {
 		case <-stopChan:


### PR DESCRIPTION
We need to stop sending messages to the signal channel before closing it or we can get a panic during shutdown.