### PR TITLE
Adding the `error.*` domains

### DIFF
--- a/docs/content/metrics/domains/error.account/_index.md
+++ b/docs/content/metrics/domains/error.account/_index.md
@@ -1,0 +1,130 @@
+---
+title: "error.account"
+---
+
+The `error.account` domain includes server error metrics grouped by account from [error summary tables](https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html).
+
+{{< toc >}}
+
+## Usage 
+
+For example:
+
+```
+mysql> SELECT * FROM performance_schema.events_errors_summary_by_account_by_error WHERE error_number = 3024 AND USER IN ('user')\G
+*************************** 1. row ***************************
+             USER: user
+             HOST: localhost
+     ERROR_NUMBER: 3024
+       ERROR_NAME: ER_QUERY_TIMEOUT
+        SQL_STATE: HY000
+ SUM_ERROR_RAISED: 1
+SUM_ERROR_HANDLED: 0
+       FIRST_SEEN: 2025-04-30 16:30:16
+        LAST_SEEN: 2025-04-30 16:30:16
+```
+
+The `SUM_ERR_RAISED` value is used for the Blip `raised` metric. `ERROR_NUMBER`, `ERROR_NAME`, `USER`, and `HOST` are used to group the metric.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Collect metrics on _all_ errors (not recommended)|
+|no   | |Collect only metrics for the errors listed in the plan|
+|exclude| |Collect metrics only for errors that are not listed in the plan|
+
+### `total`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Return the total number of errors raised|
+|no   | |Do not return the total number of errors raised|
+|only| |Only return the total number of errors raised|
+
+If `all` is not set to `yes` the total will only reflect those errors that are specifically included or not excluded from collection.
+
+### `include`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of accounts|
+|**Default**||
+
+A comma-separated list of ids to include. Overrides option `exclude`. The values for the filter should be formatted as `user@hostname`. Wildcards are allowed for either `user` or `hostname`, but not both. Invalid values will be ignored.
+
+### `exclude`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of accounts|
+|**Default**||
+
+A comma-separated list of ids to exclude. Ignored if `include` is set. The values for the filter should be formatted as `user@hostname`. Wildcards are allowed for either `user` or `hostname`, but not both. Invalid values will be ignored.
+
+### `truncate-table`
+
+|Value|Default|Description|
+|---|---|---|
+|yes| |Truncate table after each successful collection|
+|no|&check; |Do not truncate table|
+
+If the table is truncated (default), the metrics are delta counters.
+Else, the values are cumulative counters.
+
+### `truncate-timeout`
+
+| | |
+|---|---|
+|**Value Type**|[Duration string](https://pkg.go.dev/time#ParseDuration)|250ms|
+|**Default**|250ms|
+
+Sets `@@session.lock_wait_timeout` to avoid waiting too long when truncating the table.
+Normally, truncating a table is nearly instantaneous, but metadata locks can block the operation.
+
+### `truncate-on-startup`
+
+|Value|Default|Description|
+|---|---|---|
+|yes|&check;|Truncate source table on start of metric collection|
+|no| |Do not truncate source table on startup|
+
+Truncates the source table when Blip starts. The timeout use will be the same as specified by `truncate-timeout`.
+
+## Group Keys
+
+|Key|Value|
+|---|---|
+|`error_nunmber`|The error number or an empty string for a total|
+|`error_name`|The short error name or an empty string for a total|
+|`error_user`|The user name for the error|
+|`error_host`|The host for the error|
+
+## Meta
+
+None.
+
+## Error Policies
+
+|Name|MySQL Error|
+|----|-----------|
+|`truncate-timeout`|Error truncating table|
+
+## MySQL Config
+
+See
+* [29.12.20.11 Error Summary Tables](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)
+
+and related pages in the MySQL manual.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/error.global/_index.md
+++ b/docs/content/metrics/domains/error.global/_index.md
@@ -1,0 +1,108 @@
+---
+title: "error.global"
+---
+
+The `error.global` domain includes global server error metrics from [error summary tables](https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html).
+
+{{< toc >}}
+
+## Usage 
+
+For example:
+
+```
+mysql> SELECT * FROM performance_schema.events_errors_summary_global_by_error WHERE error_number = 3024\G
+*************************** 1. row ***************************
+     ERROR_NUMBER: 3024
+       ERROR_NAME: ER_QUERY_TIMEOUT
+        SQL_STATE: HY000
+ SUM_ERROR_RAISED: 1
+SUM_ERROR_HANDLED: 0
+       FIRST_SEEN: 2025-04-30 16:30:16
+        LAST_SEEN: 2025-04-30 16:30:16
+```
+
+The `SUM_ERR_RAISED` value is used for the Blip `raised` metric. `ERROR_NUMBER` and `ERROR_NAME` are used to group the metric.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Collect metrics on _all_ errors (not recommended)|
+|no   | |Collect only metrics for the errors listed in the plan|
+|exclude| |Collect metrics only for errors that are not listed in the plan|
+
+### `total`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Return the total number of errors raised|
+|no   | |Do not return the total number of errors raised|
+|only| |Only return the total number of errors raised|
+
+If `all` is not set to `yes` the total will only reflect those errors that are specifically included or not excluded from collection.
+
+### `truncate-table`
+
+|Value|Default|Description|
+|---|---|---|
+|yes| |Truncate table after each successful collection|
+|no|&check; |Do not truncate table|
+
+If the table is truncated (default), the metrics are delta counters.
+Else, the values are cumulative counters.
+
+### `truncate-timeout`
+
+| | |
+|---|---|
+|**Value Type**|[Duration string](https://pkg.go.dev/time#ParseDuration)|250ms|
+|**Default**|250ms|
+
+Sets `@@session.lock_wait_timeout` to avoid waiting too long when truncating the table.
+Normally, truncating a table is nearly instantaneous, but metadata locks can block the operation.
+
+### `truncate-on-startup`
+
+|Value|Default|Description|
+|---|---|---|
+|yes|&check;|Truncate source table on start of metric collection|
+|no| |Do not truncate source table on startup|
+
+Truncates the source table when Blip starts. The timeout use will be the same as specified by `truncate-timeout`.
+
+## Group Keys
+
+|Key|Value|
+|---|---|
+|`error_nunmber`|The error number or an empty string for a total|
+|`error_name`|The short error name or an empty string for a total|
+
+## Meta
+
+None.
+
+## Error Policies
+
+|Name|MySQL Error|
+|----|-----------|
+|`truncate-timeout`|Error truncating table|
+
+## MySQL Config
+
+See
+* [29.12.20.11 Error Summary Tables](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)
+
+and related pages in the MySQL manual.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/error.host/_index.md
+++ b/docs/content/metrics/domains/error.host/_index.md
@@ -1,0 +1,128 @@
+---
+title: "error.host"
+---
+
+The `error.host` domain includes server error metrics grouped by host from [error summary tables](https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html).
+
+{{< toc >}}
+
+## Usage 
+
+For example:
+
+```
+mysql> SELECT * FROM performance_schema.events_errors_summary_by_host_by_error WHERE error_number = 3024 AND HOST IN ('host1')\G
+*************************** 1. row ***************************
+             HOST: host1
+     ERROR_NUMBER: 3024
+       ERROR_NAME: ER_QUERY_TIMEOUT
+        SQL_STATE: HY000
+ SUM_ERROR_RAISED: 1
+SUM_ERROR_HANDLED: 0
+       FIRST_SEEN: 2025-04-30 16:30:16
+        LAST_SEEN: 2025-04-30 16:30:16
+```
+
+The `SUM_ERR_RAISED` value is used for the Blip `raised` metric. `ERROR_NUMBER`, `ERROR_NAME`, and `HOST` are used to group the metric.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Collect metrics on _all_ errors (not recommended)|
+|no   | |Collect only metrics for the errors listed in the plan|
+|exclude| |Collect metrics only for errors that are not listed in the plan|
+
+### `total`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Return the total number of errors raised|
+|no   | |Do not return the total number of errors raised|
+|only| |Only return the total number of errors raised|
+
+If `all` is not set to `yes` the total will only reflect those errors that are specifically included or not excluded from collection.
+
+### `include`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of hosts|
+|**Default**||
+
+A comma-separated list of hosts to include. Overrides option `exclude`. 
+
+### `exclude`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of hosts|
+|**Default**||
+
+A comma-separated list of hosts to exclude. Ignored if `include` is set. 
+
+### `truncate-table`
+
+|Value|Default|Description|
+|---|---|---|
+|yes| |Truncate table after each successful collection|
+|no|&check; |Do not truncate table|
+
+If the table is truncated (default), the metrics are delta counters.
+Else, the values are cumulative counters.
+
+### `truncate-timeout`
+
+| | |
+|---|---|
+|**Value Type**|[Duration string](https://pkg.go.dev/time#ParseDuration)|250ms|
+|**Default**|250ms|
+
+Sets `@@session.lock_wait_timeout` to avoid waiting too long when truncating the table.
+Normally, truncating a table is nearly instantaneous, but metadata locks can block the operation.
+
+### `truncate-on-startup`
+
+|Value|Default|Description|
+|---|---|---|
+|yes|&check;|Truncate source table on start of metric collection|
+|no| |Do not truncate source table on startup|
+
+Truncates the source table when Blip starts. The timeout use will be the same as specified by `truncate-timeout`.
+
+## Group Keys
+
+|Key|Value|
+|---|---|
+|`error_nunmber`|The error number or an empty string for a total|
+|`error_name`|The short error name or an empty string for a total|
+|`error_host`|The host for the error|
+
+## Meta
+
+None.
+
+## Error Policies
+
+|Name|MySQL Error|
+|----|-----------|
+|`truncate-timeout`|Error truncating table|
+
+## MySQL Config
+
+See
+* [29.12.20.11 Error Summary Tables](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)
+
+and related pages in the MySQL manual.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/error.thread/_index.md
+++ b/docs/content/metrics/domains/error.thread/_index.md
@@ -1,0 +1,128 @@
+---
+title: "error.thread"
+---
+
+The `error.thread` domain includes server error metrics grouped by thread from [error summary tables](https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html).
+
+{{< toc >}}
+
+## Usage 
+
+For example:
+
+```
+mysql> SELECT * FROM performance_schema.events_errors_summary_by_thread_by_error WHERE error_number = 3024 AND THREAD_ID IN (1)\G
+*************************** 1. row ***************************
+        THREAD_ID: 1
+     ERROR_NUMBER: 3024
+       ERROR_NAME: ER_QUERY_TIMEOUT
+        SQL_STATE: HY000
+ SUM_ERROR_RAISED: 1
+SUM_ERROR_HANDLED: 0
+       FIRST_SEEN: 2025-04-30 16:30:16
+        LAST_SEEN: 2025-04-30 16:30:16
+```
+
+The `SUM_ERR_RAISED` value is used for the Blip `raised` metric. `ERROR_NUMBER`, `ERROR_NAME`, and `THREAD_ID` are used to group the metric.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Collect metrics on _all_ errors (not recommended)|
+|no   | |Collect only metrics for the errors listed in the plan|
+|exclude| |Collect metrics only for errors that are not listed in the plan|
+
+### `total`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Return the total number of errors raised|
+|no   | |Do not return the total number of errors raised|
+|only| |Only return the total number of errors raised|
+
+If `all` is not set to `yes` the total will only reflect those errors that are specifically included or not excluded from collection.
+
+### `include`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of thread ids|
+|**Default**||
+
+A comma-separated list of ids to include. Overrides option `exclude`. 
+
+### `exclude`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of ids|
+|**Default**||
+
+A comma-separated list of ids to exclude. Ignored if `include` is set. 
+
+### `truncate-table`
+
+|Value|Default|Description|
+|---|---|---|
+|yes| |Truncate table after each successful collection|
+|no|&check; |Do not truncate table|
+
+If the table is truncated (default), the metrics are delta counters.
+Else, the values are cumulative counters.
+
+### `truncate-timeout`
+
+| | |
+|---|---|
+|**Value Type**|[Duration string](https://pkg.go.dev/time#ParseDuration)|250ms|
+|**Default**|250ms|
+
+Sets `@@session.lock_wait_timeout` to avoid waiting too long when truncating the table.
+Normally, truncating a table is nearly instantaneous, but metadata locks can block the operation.
+
+### `truncate-on-startup`
+
+|Value|Default|Description|
+|---|---|---|
+|yes|&check;|Truncate source table on start of metric collection|
+|no| |Do not truncate source table on startup|
+
+Truncates the source table when Blip starts. The timeout use will be the same as specified by `truncate-timeout`.
+
+## Group Keys
+
+|Key|Value|
+|---|---|
+|`error_nunmber`|The error number or an empty string for a total|
+|`error_name`|The short error name or an empty string for a total|
+|`error_thread`|The thread id for the error|
+
+## Meta
+
+None.
+
+## Error Policies
+
+|Name|MySQL Error|
+|----|-----------|
+|`truncate-timeout`|Error truncating table|
+
+## MySQL Config
+
+See
+* [29.12.20.11 Error Summary Tables](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)
+
+and related pages in the MySQL manual.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/error.user/_index.md
+++ b/docs/content/metrics/domains/error.user/_index.md
@@ -1,0 +1,128 @@
+---
+title: "error.user"
+---
+
+The `error.user` domain includes server error metrics grouped by user from [error summary tables](https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html).
+
+{{< toc >}}
+
+## Usage 
+
+For example:
+
+```
+mysql> SELECT * FROM performance_schema.events_errors_summary_by_user_by_error WHERE error_number = 3024 AND USER IN ('example')\G
+*************************** 1. row ***************************
+             USER: example
+     ERROR_NUMBER: 3024
+       ERROR_NAME: ER_QUERY_TIMEOUT
+        SQL_STATE: HY000
+ SUM_ERROR_RAISED: 1
+SUM_ERROR_HANDLED: 0
+       FIRST_SEEN: 2025-04-30 16:30:16
+        LAST_SEEN: 2025-04-30 16:30:16
+```
+
+The `SUM_ERR_RAISED` value is used for the Blip `raised` metric. `ERROR_NUMBER`, `ERROR_NAME`, and `USER` are used to group the metric.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Collect metrics on _all_ errors (not recommended)|
+|no   | |Collect only metrics for the errors listed in the plan|
+|exclude| |Collect metrics only for errors that are not listed in the plan|
+
+### `total`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  |&check; |Return the total number of errors raised|
+|no   | |Do not return the total number of errors raised|
+|only| |Only return the total number of errors raised|
+
+If `all` is not set to `yes` the total will only reflect those errors that are specifically included or not excluded from collection.
+
+### `include`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of users|
+|**Default**||
+
+A comma-separated list of users to include. Overrides option `exclude`. 
+
+### `exclude`
+
+| | |
+|---|---|
+|**Value Type**|CSV string of users|
+|**Default**|event_scheduler|
+
+A comma-separated list of users to exclude. Ignored if `include` is set. 
+
+### `truncate-table`
+
+|Value|Default|Description|
+|---|---|---|
+|yes| |Truncate table after each successful collection|
+|no|&check; |Do not truncate table|
+
+If the table is truncated (default), the metrics are delta counters.
+Else, the values are cumulative counters.
+
+### `truncate-timeout`
+
+| | |
+|---|---|
+|**Value Type**|[Duration string](https://pkg.go.dev/time#ParseDuration)|250ms|
+|**Default**|250ms|
+
+Sets `@@session.lock_wait_timeout` to avoid waiting too long when truncating the table.
+Normally, truncating a table is nearly instantaneous, but metadata locks can block the operation.
+
+### `truncate-on-startup`
+
+|Value|Default|Description|
+|---|---|---|
+|yes|&check;|Truncate source table on start of metric collection|
+|no| |Do not truncate source table on startup|
+
+Truncates the source table when Blip starts. The timeout use will be the same as specified by `truncate-timeout`.
+
+## Group Keys
+
+|Key|Value|
+|---|---|
+|`error_nunmber`|The error number or an empty string for a total|
+|`error_name`|The short error name or an empty string for a total|
+|`error_user`|The user for the error|
+
+## Meta
+
+None.
+
+## Error Policies
+
+|Name|MySQL Error|
+|----|-----------|
+|`truncate-timeout`|Error truncating table|
+
+## MySQL Config
+
+See
+* [29.12.20.11 Error Summary Tables](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)
+
+and related pages in the MySQL manual.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/innodb.buffer-pool/_index.md
+++ b/docs/content/metrics/domains/innodb.buffer-pool/_index.md
@@ -1,0 +1,57 @@
+---
+title: "innodb.buffer-pool"
+---
+
+The `innodb.buffer-pool` domain includes InnoDB metrics from [`INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS`](https://dev.mysql.com/doc/refman/8.4/en/information-schema-innodb-buffer-pool-stats-table.html). 
+
+{{< toc >}}
+
+## Usage 
+
+The metric values collected are aggregated over all buffer pools.
+
+For example:
+
+```
+mysql> SELECT SUM(POOL_SIZE) POOL_SIZE, SUM(FREE_BUFFERS) FREE_BUFFERS FROM INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS\G
+*************************** 1. row ***************************
+   POOL_SIZE: 95110
+   FREE_BUFFERS: 9322
+```
+
+The exact `NAME` value is used for the Blip metric name.
+
+## Derived Metrics
+
+None.
+
+## Options
+
+### `all`
+
+|Value|Default|Description|
+|-----|-------|-----------|
+|yes  | |Collect _all_ 30+ metrics (not recommended)|
+|no   |&check;|Collect only metrics listed in the plan|
+
+## Group Keys
+
+None.
+
+## Meta
+
+None.
+
+## Error Policies
+
+None.
+
+## MySQL Config
+
+None.
+
+## Changelog
+
+|Blip Version|Change|
+|------------|------|
+|TBD      |Domain added|

--- a/docs/content/metrics/domains/innodb/_index.md
+++ b/docs/content/metrics/domains/innodb/_index.md
@@ -1,25 +1,79 @@
 ---
-title: "innodb.buffer-pool"
+title: "innodb"
 ---
 
-The `innodb.buffer-pool` domain includes InnoDB metrics from [`INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS`](https://dev.mysql.com/doc/refman/8.4/en/information-schema-innodb-buffer-pool-stats-table.html). 
+The `innodb` domain includes InnoDB metrics from [`INFORMATION_SCHEMA.INNODB_METRICS`](https://dev.mysql.com/doc/refman/en/information-schema-innodb-metrics-table.html).
 
 {{< toc >}}
 
 ## Usage 
 
-The metric values collected are aggregated over all buffer pools.
-
 For example:
 
 ```
-mysql> SELECT SUM(POOL_SIZE) POOL_SIZE, SUM(FREE_BUFFERS) FREE_BUFFERS FROM INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS\G
+mysql> SELECT * FROM innodb_metrics WHERE name='trx_rseg_history_len' LIMIT 1\G
 *************************** 1. row ***************************
-   POOL_SIZE: 95110
-   FREE_BUFFERS: 9322
+           NAME: trx_rseg_history_len
+      SUBSYSTEM: transaction
+          COUNT: 0
+      MAX_COUNT: 0
+      MIN_COUNT: 0
+      AVG_COUNT: NULL
+    COUNT_RESET: 0
+MAX_COUNT_RESET: 0
+MIN_COUNT_RESET: 0
+AVG_COUNT_RESET: NULL
+   TIME_ENABLED: 2021-08-17 08:24:14
+  TIME_DISABLED: NULL
+   TIME_ELAPSED: 1905927
+     TIME_RESET: NULL
+         STATUS: enabled
+           TYPE: value
+        COMMENT: Length of the TRX_RSEG_HISTORY list
 ```
 
 The exact `NAME` value is used for the Blip metric name.
+In the example above, the Blip metric name is `trx_rseg_history_len`, even though this metric means history list length (HLL).
+Metric names are unique by `SUBSYSTEM`.
+
+The [`status.global`]({{< ref "metrics/domains/status.global/" >}}) domain includes many of the same metrics because, historically, only `SHOW GLOBAL STATUS` existed.
+It's a best practice to collect InnoDB metrics with this domain and exclude them from [`status.global`]({{< ref "metrics/domains/status.global/" >}}).
+
+As a starting point, these are good InnoDB metrics to collect:
+
+```yaml
+plan:
+  collect:
+    innodb:
+      metrics:
+        # Transactions
+        - "trx_active_transactions"
+        
+        # Row locking
+        - "lock_timeouts"
+        - "lock_row_lock_current_waits"
+        - "lock_row_lock_waits"
+        - "lock_row_lock_time"
+        
+        # Page flushing
+        - "buffer_flush_adaptive_total_pages"   #  adaptive flushing
+        - "buffer_LRU_batch_flush_total_pages"  #  LRU flushing
+        - "buffer_flush_background_total_pages" #  legacy flushing
+        
+        # Transaction log utilization (%)
+        - "log_lsn_checkpoint_age"     # checkpoint age
+        - "log_max_modified_age_async" # async flush point
+        
+        # Transaction log -> storage waits
+        - "innodb_os_log_pending_writes"
+        - "innodb_log_waits"
+        
+        # History List Length (HLL)
+        - "trx_rseg_history_len"
+        
+        # Deadlocks
+        - "lock_deadlocks"
+``` 
 
 ## Derived Metrics
 
@@ -31,8 +85,9 @@ None.
 
 |Value|Default|Description|
 |-----|-------|-----------|
-|yes  | |Collect _all_ 30+ metrics (not recommended)|
+|yes  | |Collect _all_ 300+ metrics (not recommended)|
 |no   |&check;|Collect only metrics listed in the plan|
+|enabled| |Collect metrics that are enabled by MySQL (`WHERE status='enabled'`)|
 
 ## Group Keys
 
@@ -40,7 +95,12 @@ None.
 
 ## Meta
 
-None.
+|Key|Value|
+|---|-----|
+|`subsystem`|`SUBSYSTEM` column|
+
+Technically InnoDB metric names are unique by subsystem, but currently they're unique for the whole table.
+It's probably safe to graph them by metric name alone, but if there's a name collision in the future, one metrics will be lost when reporting.
 
 ## Error Policies
 
@@ -48,10 +108,10 @@ None.
 
 ## MySQL Config
 
-None.
+See [17.15.6 InnoDB INFORMATION_SCHEMA Metrics Table](https://dev.mysql.com/doc/refman/en/innodb-information-schema-metrics-table.html).
 
 ## Changelog
 
 |Blip Version|Change|
 |------------|------|
-|TBD      |Domain added|
+|v1.0.0      |Domain added|

--- a/docs/content/metrics/quick-ref.md
+++ b/docs/content/metrics/quick-ref.md
@@ -19,7 +19,11 @@ The rest are reserved for future use.
 |azure|Microsoft Azure||
 |error|MySQL, client, and query errors||
 |error.client|Client errors||
-|error.global|Global error counts and rates||
+|[error.account](domains#error.account)|Error counts and rates by account [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|TBD|
+|[error.global](domains#error.global)|Global error counts and rates [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|TBD|
+|[error.host](domains#error.host)|Error counts and rates by host [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|TBD|
+|[error.thread](domains#error.thread)|Error counts and rates by thread [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|TBD|
+|[error.user](domains#error.user)|Error counts and rates by user [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|TBD|
 |error.query|Query errors||
 |error.repl|Replication errors||
 |event|[MySQL Event Scheduler](https://dev.mysql.com/doc/refman/8.0/en/event-scheduler.html)||

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/prometheus/common v0.44.0
 	github.com/signalfx/golib/v3 v3.3.36
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/text v0.14.0
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/metrics/error/account.go
+++ b/metrics/error/account.go
@@ -1,0 +1,176 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cashapp/blip"
+)
+
+const (
+	TRUNCATE_QUERY_ACCOUNT = "TRUNCATE TABLE performance_schema.events_errors_summary_by_account_by_error"
+	BASE_QUERY_ACCOUNT     = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error"
+	GROUP_BY_ACCOUNT       = " GROUP BY USER, HOST"
+)
+
+// ErrorAccount collects error summary information for the error.account domain.
+// https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html
+type ErrorAccount struct {
+	db *sql.DB
+	// --
+	options map[string]*errorLevelOptions
+}
+
+// Verify collector implements blip.Collector interface.
+var _ blip.Collector = &ErrorAccount{}
+
+// NewErrorAccount makes a new Table collector,
+func NewErrorAccount(db *sql.DB) *ErrorAccount {
+	return &ErrorAccount{
+		db:      db,
+		options: make(map[string]*errorLevelOptions),
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (t *ErrorAccount) Domain() string {
+	return DOMAIN + "." + SUB_DOMAIN_ACCOUNT
+}
+
+// Help returns the output for blip --print-domains.
+func (t *ErrorAccount) Help() blip.CollectorHelp {
+	h := help(SUB_DOMAIN_ACCOUNT)
+	h.Groups = append(h.Groups, []blip.CollectorKeyValue{
+		{Key: GRP_ERR_USER, Value: "the user for the corresponding error"},
+		{Key: GRP_ERR_HOST, Value: "the host for the corresponding error"},
+	}...)
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name: OPT_INCLUDE,
+		Desc: fmt.Sprintf("Comma-separated list of accounts (user@host) to include (overrides option %s)", OPT_EXCLUDE),
+	}
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name:    OPT_EXCLUDE,
+		Desc:    fmt.Sprintf("Comma-separated list of accounts (user@host) to exclude (ignored if %s is set).", OPT_INCLUDE),
+		Default: "event_scheduler",
+	}
+
+	return h
+}
+
+// Prepare prepares the collector for the given plan.
+func (t *ErrorAccount) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[t.Domain()]
+		if !ok {
+			continue
+		}
+		if dom.Options == nil {
+			dom.Options = make(map[string]string)
+		}
+
+		errOpts, err := prepare(dom, SUB_DOMAIN_ACCOUNT, BASE_QUERY_ACCOUNT, GROUP_BY_ACCOUNT)
+		if err != nil {
+			return nil, err
+		}
+
+		t.options[level.Name] = errOpts
+
+		// Run an initial truncate to clear out any old data
+		if errOpts.truncateOnStartup {
+			err := t.truncate(ctx, level.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to truncate table for %s on level %s: %v", t.Domain(), level.Name, err)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (t *ErrorAccount) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		metrics   []blip.MetricValue
+		errors    int64
+		errorNum  string
+		errorName string
+		user      string
+		host      string
+		total     map[account]float64 = make(map[account]float64)
+	)
+
+	for rows.Next() {
+		if err = rows.Scan(&errors, &errorNum, &errorName, &user, &host); err != nil {
+			return nil, err
+		}
+
+		m := blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: errorNum, GRP_ERR_NAME: errorName, GRP_ERR_USER: user, GRP_ERR_HOST: host},
+			Value: float64(errors),
+		}
+
+		metrics = append(metrics, m)
+
+		accountKey := account{
+			User: user,
+			Host: host,
+		}
+		if _, ok := total[accountKey]; !ok {
+			total[accountKey] = 0
+		}
+		total[accountKey] += float64(errors)
+	}
+
+	if o.emitTotal {
+		for account, value := range total {
+			metrics = append(metrics, blip.MetricValue{
+				Name:  "raised",
+				Type:  o.metricType,
+				Group: map[string]string{GRP_ERR_NUMBER: "", GRP_ERR_NAME: "", GRP_ERR_USER: account.User, GRP_ERR_HOST: account.Host},
+				Value: value,
+			})
+		}
+	}
+
+	if o.truncate {
+		err = t.truncate(ctx, levelName)
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
+		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
+	}
+
+	return metrics, err
+}
+
+func (t *ErrorAccount) truncate(ctx context.Context, levelName string) error {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil
+	}
+
+	return truncate(ctx, t.db, o, TRUNCATE_QUERY_ACCOUNT)
+}
+
+type account struct {
+	User string
+	Host string
+}
+
+func (a account) String() string {
+	return fmt.Sprintf("%s@%s", a.User, a.Host)
+}

--- a/metrics/error/error.go
+++ b/metrics/error/error.go
@@ -1,0 +1,215 @@
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+const (
+	DOMAIN = "error"
+
+	SUB_DOMAIN_ACCOUNT = "account"
+	SUB_DOMAIN_GLOBAL  = "global"
+	SUB_DOMAIN_USER    = "user"
+	SUB_DOMAIN_HOST    = "host"
+	SUB_DOMAIN_THREAD  = "thread"
+
+	OPT_ALL                 = "all"
+	OPT_INCLUDE             = "include"
+	OPT_EXCLUDE             = "exclude"
+	OPT_TRUNCATE_TABLE      = "truncate-table"
+	OPT_TRUNCATE_TIMEOUT    = "truncate-timeout"
+	OPT_TRUNCATE_ON_STARTUP = "truncate-on-startup"
+	OPT_TOTAL               = "total"
+
+	ERR_TRUNCATE_FAILED = "truncate-timeout"
+	LOCKWAIT_QUERY      = "SET @@session.lock_wait_timeout=%d"
+
+	GRP_ERR_NUMBER = "error_number"
+	GRP_ERR_NAME   = "error_name"
+	GRP_ERR_USER   = "error_user"
+	GRP_ERR_HOST   = "error_host"
+	GRP_ERR_THREAD = "error_thread"
+)
+
+type errorLevelOptions struct {
+	query             string
+	params            []any
+	truncate          bool
+	truncateOnStartup bool
+	truncateTimeout   time.Duration
+	lockWaitQuery     string
+	stop              bool
+	truncateErrPolicy *errors.TruncateErrorPolicy
+	metricType        byte
+	emitTotal         bool
+}
+
+// Returns a default help message for error collectors
+func help(subdomain string) blip.CollectorHelp {
+	return blip.CollectorHelp{
+		Domain:      DOMAIN + "." + subdomain,
+		Description: fmt.Sprintf("Errors Summary by %s", cases.Title(language.English).String(subdomain)),
+		Options: map[string]blip.CollectorHelpOption{
+			OPT_ALL: {
+				Name:    OPT_ALL,
+				Desc:    "Collect all errors",
+				Default: "yes",
+				Values: map[string]string{
+					"yes":     "All errors (ignore metrics list)",
+					"no":      "Specified metrics",
+					"exclude": "Excludes specified metrics",
+				},
+			},
+			OPT_TOTAL: {
+				Name:    OPT_TOTAL,
+				Desc:    fmt.Sprintf("Return the total number of errors raised, grouped by %s", subdomain),
+				Default: "yes",
+				Values: map[string]string{
+					"yes":  "Return the total number of errors raised",
+					"no":   "Do not return the total number of errors raised",
+					"only": "Only return the total number of errors raised",
+				},
+			},
+			OPT_TRUNCATE_TABLE: {
+				Name:    OPT_TRUNCATE_TABLE,
+				Desc:    "If the source table should be truncated to reset data after each retrieval",
+				Default: "no",
+				Values: map[string]string{
+					"yes": "Truncate source table after each retrieval",
+					"no":  "Do not truncate source table after each retrieval",
+				},
+			},
+			OPT_TRUNCATE_TIMEOUT: {
+				Name:    OPT_TRUNCATE_TIMEOUT,
+				Desc:    "The amount of time to attempt to truncate the source table before timing out",
+				Default: "250ms",
+			},
+			OPT_TRUNCATE_ON_STARTUP: {
+				Name:    OPT_TRUNCATE_ON_STARTUP,
+				Desc:    "If the source table should be truncated on the start of metric collection. Truncation will use the timeout specified in " + OPT_TRUNCATE_TIMEOUT,
+				Default: "yes",
+				Values: map[string]string{
+					"yes": "Truncate source table on startup",
+					"no":  "Do not truncate source table on startup",
+				},
+			},
+		},
+		Groups: []blip.CollectorKeyValue{
+			{Key: GRP_ERR_NUMBER, Value: "the error number, or an empty string for a total"},
+			{Key: GRP_ERR_NAME, Value: "the error name, or an empty string for a total"},
+		},
+		Metrics: []blip.CollectorMetric{
+			{
+				Name: "raised",
+				Type: blip.CUMULATIVE_COUNTER,
+				Desc: "Raised errors",
+			},
+		},
+		Errors: map[string]blip.CollectorHelpError{
+			ERR_TRUNCATE_FAILED: {
+				Name:    ERR_TRUNCATE_FAILED,
+				Handles: "Truncation failures on error summary tables",
+				Default: errors.NewPolicy("").String(),
+			},
+		},
+	}
+}
+
+// Prepares the error level options for the given domain and query.
+func prepare(dom blip.Domain, subdomain, baseQuery, groupBy string) (*errorLevelOptions, error) {
+	if dom.Options == nil {
+		dom.Options = make(map[string]string)
+	}
+
+	if _, ok := dom.Options[OPT_ALL]; !ok {
+		dom.Options[OPT_ALL] = "yes"
+	}
+
+	if _, ok := dom.Options[OPT_TOTAL]; !ok {
+		dom.Options[OPT_TOTAL] = "yes"
+	}
+
+	errOpts, err := ErrorsQuery(dom, baseQuery, groupBy, subdomain)
+	if err != nil {
+		return nil, err
+	}
+
+	if total := strings.ToLower(dom.Options[OPT_TOTAL]); total == "only" || total == "no" {
+		errOpts.emitTotal = false
+	} else {
+		errOpts.emitTotal = true
+	}
+
+	if truncate, ok := dom.Options[OPT_TRUNCATE_TABLE]; ok && strings.ToLower(truncate) == "yes" {
+		errOpts.truncate = true
+		errOpts.metricType = blip.DELTA_COUNTER
+	} else {
+		errOpts.truncate = false // default
+		errOpts.metricType = blip.CUMULATIVE_COUNTER
+	}
+
+	if truncateTimeout, ok := dom.Options[OPT_TRUNCATE_TIMEOUT]; ok && errOpts.truncate {
+		if duration, err := time.ParseDuration(truncateTimeout); err != nil {
+			return nil, fmt.Errorf("invalid truncate duration: %v", err)
+		} else {
+			errOpts.truncateTimeout = duration
+		}
+	} else {
+		errOpts.truncateTimeout = 250 * time.Millisecond // default
+	}
+
+	errOpts.truncateOnStartup = true
+	if truncate := strings.ToLower(dom.Options[OPT_TRUNCATE_ON_STARTUP]); truncate == "no" {
+		errOpts.truncateOnStartup = false
+	}
+
+	if errOpts.truncate || errOpts.truncateOnStartup {
+		// Setup our lock wait timeout. It needs to be at least as long
+		// as our truncate timeout, but the granularity of the lock wait
+		// timeout is seconds, so we round up to the nearest second that is
+		// greater than our truncate timeout.
+		lockWaitTimeout := math.Ceil(errOpts.truncateTimeout.Seconds())
+		if lockWaitTimeout < 1.0 {
+			lockWaitTimeout = 1
+		}
+
+		errOpts.lockWaitQuery = fmt.Sprintf(LOCKWAIT_QUERY, int64(lockWaitTimeout))
+		errOpts.truncateErrPolicy = errors.NewTruncateErrorPolicy(dom.Errors[ERR_TRUNCATE_FAILED])
+		blip.Debug("error policy: %s=%s", ERR_TRUNCATE_FAILED, errOpts.truncateErrPolicy.Policy)
+	}
+
+	return errOpts, nil
+}
+
+// Executes a TRUNCATE TABLE statement on the given database connection.
+func truncate(ctx context.Context, db *sql.DB, o *errorLevelOptions, truncateQuery string) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Set `lock_wait_timeout` to prevent our query from being blocked for too long
+	// due to metadata locking. We treat a failure to set the lock wait timeout
+	// the same as a truncate timeout, as not setting creates a risk of having a thread
+	// hang for an extended period of time.
+	_, err = conn.ExecContext(ctx, o.lockWaitQuery)
+	if err != nil {
+		return err
+	}
+
+	trCtx, cancelFn := context.WithTimeout(ctx, o.truncateTimeout)
+	defer cancelFn()
+	_, err = conn.ExecContext(trCtx, truncateQuery)
+	return err
+}

--- a/metrics/error/global.go
+++ b/metrics/error/global.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cashapp/blip"
+)
+
+const (
+	TRUNCATE_QUERY_GLOBAL = "TRUNCATE TABLE performance_schema.events_errors_summary_global_by_error"
+	BASE_QUERY_GLOBAL     = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME FROM performance_schema.events_errors_summary_global_by_error"
+	GROUP_BY_GLOBAL       = ""
+)
+
+// ErrorGlobal collects error summary information for the error.global domain.
+// https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html
+type ErrorGlobal struct {
+	db *sql.DB
+	// --
+	options map[string]*errorLevelOptions
+}
+
+// Verify collector implements blip.Collector interface.
+var _ blip.Collector = &ErrorGlobal{}
+
+// NewErrorGlobal makes a new Table collector,
+func NewErrorGlobal(db *sql.DB) *ErrorGlobal {
+	return &ErrorGlobal{
+		db:      db,
+		options: make(map[string]*errorLevelOptions),
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (t *ErrorGlobal) Domain() string {
+	return DOMAIN + "." + SUB_DOMAIN_GLOBAL
+}
+
+// Help returns the output for blip --print-domains.
+func (t *ErrorGlobal) Help() blip.CollectorHelp {
+	return help(SUB_DOMAIN_GLOBAL)
+}
+
+// Prepare prepares the collector for the given plan.
+func (t *ErrorGlobal) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[t.Domain()]
+		if !ok {
+			continue
+		}
+		if dom.Options == nil {
+			dom.Options = make(map[string]string)
+		}
+
+		errOpts, err := prepare(dom, SUB_DOMAIN_GLOBAL, BASE_QUERY_GLOBAL, GROUP_BY_GLOBAL)
+		if err != nil {
+			return nil, err
+		}
+
+		t.options[level.Name] = errOpts
+
+		// Run an initial truncate to clear out any old data
+		if errOpts.truncateOnStartup {
+			err := t.truncate(ctx, level.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to truncate table for %s on level %s: %v", t.Domain(), level.Name, err)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (t *ErrorGlobal) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		metrics   []blip.MetricValue
+		errors    int64
+		errorNum  string
+		errorName string
+		total     float64
+	)
+
+	for rows.Next() {
+		if err = rows.Scan(&errors, &errorNum, &errorName); err != nil {
+			return nil, err
+		}
+
+		m := blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: errorNum, GRP_ERR_NAME: errorName},
+			Value: float64(errors),
+		}
+
+		metrics = append(metrics, m)
+
+		total += float64(errors)
+	}
+
+	if o.emitTotal {
+		metrics = append(metrics, blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: "", GRP_ERR_NAME: ""},
+			Value: total,
+		})
+	}
+
+	if o.truncate {
+		err = t.truncate(ctx, levelName)
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
+		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
+	}
+
+	return metrics, err
+}
+
+func (t *ErrorGlobal) truncate(ctx context.Context, levelName string) error {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil
+	}
+
+	return truncate(ctx, t.db, o, TRUNCATE_QUERY_GLOBAL)
+}

--- a/metrics/error/host.go
+++ b/metrics/error/host.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cashapp/blip"
+)
+
+const (
+	TRUNCATE_QUERY_HOST = "TRUNCATE TABLE performance_schema.events_errors_summary_by_host_by_error"
+	BASE_QUERY_HOST     = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error"
+	GROUP_BY_HOST       = " GROUP BY HOST"
+)
+
+// ErrorHost collects error summary information for the error.host domain.
+// https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html
+type ErrorHost struct {
+	db *sql.DB
+	// --
+	options map[string]*errorLevelOptions
+}
+
+// Verify collector implements blip.Collector interface.
+var _ blip.Collector = &ErrorHost{}
+
+// NewErrorHost makes a new Table collector,
+func NewErrorHost(db *sql.DB) *ErrorHost {
+	return &ErrorHost{
+		db:      db,
+		options: make(map[string]*errorLevelOptions),
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (t *ErrorHost) Domain() string {
+	return DOMAIN + "." + SUB_DOMAIN_HOST
+}
+
+// Help returns the output for blip --print-domains.
+func (t *ErrorHost) Help() blip.CollectorHelp {
+	h := help(SUB_DOMAIN_HOST)
+	h.Groups = append(h.Groups, []blip.CollectorKeyValue{
+		{Key: GRP_ERR_HOST, Value: "the host for the corresponding error"},
+	}...)
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name: OPT_INCLUDE,
+		Desc: fmt.Sprintf("Comma-separated list of hosts to include (overrides option %s)", OPT_EXCLUDE),
+	}
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name:    OPT_EXCLUDE,
+		Desc:    fmt.Sprintf("Comma-separated list of hosts to exclude (ignored if %s is set).", OPT_INCLUDE),
+		Default: "event_scheduler",
+	}
+
+	return h
+}
+
+// Prepare prepares the collector for the given plan.
+func (t *ErrorHost) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[t.Domain()]
+		if !ok {
+			continue
+		}
+		if dom.Options == nil {
+			dom.Options = make(map[string]string)
+		}
+
+		errOpts, err := prepare(dom, SUB_DOMAIN_HOST, BASE_QUERY_HOST, GROUP_BY_HOST)
+		if err != nil {
+			return nil, err
+		}
+
+		t.options[level.Name] = errOpts
+
+		// Run an initial truncate to clear out any old data
+		if errOpts.truncateOnStartup {
+			err := t.truncate(ctx, level.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to truncate table for %s on level %s: %v", t.Domain(), level.Name, err)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (t *ErrorHost) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		metrics   []blip.MetricValue
+		errors    int64
+		errorNum  string
+		errorName string
+		host      string
+		total     map[string]float64 = make(map[string]float64)
+	)
+
+	for rows.Next() {
+		if err = rows.Scan(&errors, &errorNum, &errorName, &host); err != nil {
+			return nil, err
+		}
+
+		m := blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: errorNum, GRP_ERR_NAME: errorName, GRP_ERR_HOST: host},
+			Value: float64(errors),
+		}
+
+		metrics = append(metrics, m)
+
+		if _, ok := total[host]; !ok {
+			total[host] = 0
+		}
+		total[host] += float64(errors)
+	}
+
+	if o.emitTotal {
+		for host, value := range total {
+			metrics = append(metrics, blip.MetricValue{
+				Name:  "raised",
+				Type:  o.metricType,
+				Group: map[string]string{GRP_ERR_NUMBER: "", GRP_ERR_NAME: "", GRP_ERR_HOST: host},
+				Value: value,
+			})
+		}
+	}
+
+	if o.truncate {
+		err = t.truncate(ctx, levelName)
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
+		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
+	}
+
+	return metrics, err
+}
+
+func (t *ErrorHost) truncate(ctx context.Context, levelName string) error {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil
+	}
+
+	return truncate(ctx, t.db, o, TRUNCATE_QUERY_HOST)
+}

--- a/metrics/error/query.go
+++ b/metrics/error/query.go
@@ -1,0 +1,270 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/sqlutil"
+)
+
+// ErrorsQuery builds a query for error metrics based on the domain configuration.
+// The base query and groupBy parameters allow customization for different error domains.
+func ErrorsQuery(dom blip.Domain, baseQuery string, groupBy string, subDomain string) (*errorLevelOptions, error) {
+	var query string
+	var grpBy string
+	query = baseQuery
+
+	if strings.ToLower(dom.Options[OPT_TOTAL]) == "only" {
+		// Modify the query to get totals only
+		query = strings.Replace(baseQuery, "ERROR_NUMBER, ERROR_NAME", "'' ERROR_NUMBER, '' ERROR_NAME", 1)
+		query = strings.Replace(query, "SUM_ERROR_RAISED", "SUM(SUM_ERROR_RAISED)", 1)
+		grpBy = groupBy
+	}
+
+	where, params, err := setWhere(dom, subDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	return &errorLevelOptions{
+		query:  query + where + grpBy,
+		params: params,
+	}, nil
+}
+
+// setAnd is a helper function to determine if the "AND" clause should be added to the WHERE clause.
+func setAnd(where strings.Builder) string {
+	if where.Len() == 0 {
+		return ""
+	} else {
+		return " AND"
+	}
+}
+
+func setWhere(dom blip.Domain, subDomain string) (string, []any, error) {
+	// Initialize the where clause once if we need it
+	var where strings.Builder
+	var params []any = make([]any, 0)
+	var errorNum []any = make([]any, 0)
+	var errorName []any = make([]any, 0)
+
+	if strings.ToLower(dom.Options[OPT_ALL]) != "yes" && len(dom.Metrics) > 0 {
+		var inCond, conj string
+		switch strings.ToLower(dom.Options[OPT_ALL]) {
+		case "no":
+			inCond = "IN"
+			conj = " OR "
+		case "exclude":
+			inCond = "NOT IN"
+			conj = " AND "
+		default:
+			return "", nil, fmt.Errorf("invalid option %s", dom.Options[OPT_ALL])
+		}
+
+		where.WriteString(setAnd(where))
+
+		for _, metric := range dom.Metrics {
+			if i, err := strconv.Atoi(metric); err == nil {
+				errorNum = append(errorNum, i)
+			} else {
+				errorName = append(errorName, metric)
+			}
+		}
+
+		errorConditions := make([]string, 0, 2)
+		if len(errorNum) > 0 {
+			errorConditions = append(errorConditions, fmt.Sprintf("ERROR_NUMBER %s (%s)", inCond, sqlutil.PlaceholderList(len(errorNum))))
+			params = append(params, errorNum...)
+		}
+
+		if len(errorName) > 0 {
+			errorConditions = append(errorConditions, fmt.Sprintf("ERROR_NAME %s (%s)", inCond, sqlutil.PlaceholderList(len(errorName))))
+			params = append(params, errorName...)
+		}
+
+		where.WriteString(fmt.Sprintf(" (%s)", strings.Join(errorConditions, conj)))
+	} else {
+		// Exclude NULL error numbers
+		where.WriteString(setAnd(where))
+		where.WriteString(" ERROR_NUMBER IS NOT NULL")
+	}
+
+	// Handle include/exclude filters based on the collector type
+	var subWhere string
+	var subParams []any = make([]any, 0)
+
+	switch subDomain {
+	case SUB_DOMAIN_ACCOUNT:
+		subWhere, subParams = getAccountFilters(dom)
+	case SUB_DOMAIN_USER:
+		subWhere, subParams = getUserFilters(dom)
+	case SUB_DOMAIN_HOST:
+		subWhere, subParams = getHostFilters(dom)
+	case SUB_DOMAIN_THREAD:
+		subWhere, subParams = getThreadFilters(dom)
+	case SUB_DOMAIN_GLOBAL:
+		// No additional filters needed
+	}
+
+	if len(subWhere) > 0 {
+		where.WriteString(setAnd(where))
+		where.WriteString(subWhere)
+		params = append(params, subParams...)
+	}
+
+	// Exclude errors without any errors raised
+	where.WriteString(setAnd(where))
+	where.WriteString(" SUM_ERROR_RAISED > 0")
+
+	return " WHERE" + where.String(), params, nil
+}
+
+func getAccountFilters(dom blip.Domain) (string, []any) {
+	var where strings.Builder
+	var params []any = []any{}
+	hasValidTokens := false
+	var conjunction, inOp string
+	onlyUser := []string{}
+	onlyHost := []string{}
+	onlyAccount := [][]string{}
+
+	splitTokens := func(str string) {
+		tokens := strings.Split(str, ",")
+
+		for _, token := range tokens {
+			parts := strings.Split(token, "@")
+			// Only process accounts that are in the format user@host.
+			// Wildcards are allowed for either user or host but not both.
+			if len(parts) == 2 {
+				if parts[0] == "*" && parts[1] != "*" {
+					onlyHost = append(onlyHost, parts[1])
+					hasValidTokens = true
+				} else if parts[0] != "*" && parts[1] == "*" {
+					onlyUser = append(onlyUser, parts[0])
+					hasValidTokens = true
+				} else if parts[0] != "*" && parts[1] != "*" {
+					// This is an account with a specific user and host
+					onlyAccount = append(onlyAccount, parts)
+					hasValidTokens = true
+				}
+			}
+		}
+	}
+
+	if include := dom.Options[OPT_INCLUDE]; include != "" {
+		inOp = "IN"
+		conjunction = "OR"
+		splitTokens(include)
+	} else if exclude := dom.Options[OPT_EXCLUDE]; exclude != "" {
+		inOp = "NOT IN"
+		conjunction = "AND"
+		splitTokens(exclude)
+	}
+
+	if hasValidTokens {
+		where.WriteString(setAnd(where))
+		where.WriteString(" (")
+		parts := make([]string, 0, 3)
+
+		if len(onlyAccount) > 0 {
+			parts = append(parts, fmt.Sprintf("(USER, HOST) %s (%s)", inOp, sqlutil.MultiPlaceholderList(len(onlyAccount), 2)))
+			for _, tokens := range onlyAccount {
+				params = append(params, sqlutil.ToInterfaceArray(tokens)...)
+			}
+		}
+
+		if len(onlyUser) > 0 {
+			parts = append(parts, fmt.Sprintf("USER %s (%s)", inOp, sqlutil.PlaceholderList(len(onlyUser))))
+			params = append(params, sqlutil.ToInterfaceArray(onlyUser)...)
+		}
+
+		if len(onlyHost) > 0 {
+			parts = append(parts, fmt.Sprintf("HOST %s (%s)", inOp, sqlutil.PlaceholderList(len(onlyHost))))
+			params = append(params, sqlutil.ToInterfaceArray(onlyHost)...)
+		}
+
+		where.WriteString(strings.Join(parts, fmt.Sprintf(" %s ", conjunction)))
+		where.WriteString(")")
+	}
+
+	// Ensure user and host are not NULL
+	where.WriteString(setAnd(where))
+	where.WriteString(" USER IS NOT NULL AND HOST IS NOT NULL")
+
+	return where.String(), params
+}
+
+func getUserFilters(dom blip.Domain) (string, []any) {
+	var where strings.Builder
+	var params []any = []any{}
+
+	if include := dom.Options[OPT_INCLUDE]; include != "" {
+		where.WriteString(setAnd(where))
+		users := strings.Split(include, ",")
+
+		where.WriteString(fmt.Sprintf(" USER IN (%s)", sqlutil.PlaceholderList(len(users))))
+		params = append(params, sqlutil.ToInterfaceArray(users)...)
+	} else if exclude := dom.Options[OPT_EXCLUDE]; exclude != "" {
+		where.WriteString(setAnd(where))
+		users := strings.Split(exclude, ",")
+		where.WriteString(fmt.Sprintf(" USER NOT IN (%s)", sqlutil.PlaceholderList(len(users))))
+		params = append(params, sqlutil.ToInterfaceArray(users)...)
+	} else {
+		// Exclude NULL users
+		where.WriteString(setAnd(where))
+		where.WriteString(" USER IS NOT NULL")
+	}
+
+	return where.String(), params
+}
+
+func getHostFilters(dom blip.Domain) (string, []any) {
+	var where strings.Builder
+	var params []any = []any{}
+
+	if include := dom.Options[OPT_INCLUDE]; include != "" {
+		where.WriteString(setAnd(where))
+		hosts := strings.Split(include, ",")
+
+		where.WriteString(fmt.Sprintf(" HOST IN (%s)", sqlutil.PlaceholderList(len(hosts))))
+		params = append(params, sqlutil.ToInterfaceArray(hosts)...)
+	} else if exclude := dom.Options[OPT_EXCLUDE]; exclude != "" {
+		where.WriteString(setAnd(where))
+		hosts := strings.Split(exclude, ",")
+		where.WriteString(fmt.Sprintf(" HOST NOT IN (%s)", sqlutil.PlaceholderList(len(hosts))))
+		params = append(params, sqlutil.ToInterfaceArray(hosts)...)
+	} else {
+		// Exclude NULL hosts
+		where.WriteString(setAnd(where))
+		where.WriteString(" HOST IS NOT NULL")
+	}
+
+	return where.String(), params
+}
+
+func getThreadFilters(dom blip.Domain) (string, []any) {
+	var where strings.Builder
+	var params []any = []any{}
+
+	if include := dom.Options[OPT_INCLUDE]; include != "" {
+		where.WriteString(setAnd(where))
+		threads := strings.Split(include, ",")
+		where.WriteString(fmt.Sprintf(" THREAD_ID IN (%s)", sqlutil.PlaceholderList(len(threads))))
+		params = append(params, sqlutil.ToInterfaceArray(threads)...)
+	} else if exclude := dom.Options[OPT_EXCLUDE]; exclude != "" {
+		where.WriteString(setAnd(where))
+		threads := strings.Split(exclude, ",")
+		where.WriteString(fmt.Sprintf(" THREAD_ID NOT IN (%s)", sqlutil.PlaceholderList(len(threads))))
+		params = append(params, sqlutil.ToInterfaceArray(threads)...)
+	} else {
+		// Exclude NULL thread IDs
+		where.WriteString(setAnd(where))
+		where.WriteString(" THREAD_ID IS NOT NULL")
+	}
+
+	return where.String(), params
+}

--- a/metrics/error/query_test.go
+++ b/metrics/error/query_test.go
@@ -1,0 +1,777 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/go-test/deep"
+)
+
+func TestErrorsSummariesQuery_Account_AllErrors(t *testing.T) {
+	baseQuery := BASE_QUERY_ACCOUNT
+	groupBy := GROUP_BY_ACCOUNT
+
+	// Generate by account with defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific accounts by user
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_EXCLUDE: "",
+			OPT_INCLUDE: "user1@*,user2@*",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND (USER IN (?, ?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding specific accounts by user
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_EXCLUDE: "user1@*,user2@*",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND (USER NOT IN (?, ?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific accounts by host
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_INCLUDE: "*@host1,*@host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND (HOST IN (?, ?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"host1", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding specific accounts by host
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_EXCLUDE: "*@host1,*@host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND (HOST NOT IN (?, ?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"host1", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific accounts by host
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_INCLUDE: "user1@host1,user2@host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND ((USER, HOST) IN ((?, ?), (?, ?))) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "host1", "user2", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding specific accounts by host
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_EXCLUDE: "user1@host1,user2@host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND ((USER, HOST) NOT IN ((?, ?), (?, ?))) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "host1", "user2", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including a combination of user/host, users, hosts, and invalid inputs
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_INCLUDE: "user1@host1,user3@*,user2@host2,*@host3,*@*,invalid",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND ((USER, HOST) IN ((?, ?), (?, ?)) OR USER IN (?) OR HOST IN (?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "host1", "user2", "host2", "user3", "host3"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding a combination of user/host, users, hosts, and invalid inputs
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "yes",
+			OPT_EXCLUDE: "user1@host1,user3@*,user2@host2,*@host3,*@*,invalid",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE ERROR_NUMBER IS NOT NULL AND ((USER, HOST) NOT IN ((?, ?), (?, ?)) AND USER NOT IN (?) AND HOST NOT IN (?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "host1", "user2", "host2", "user3", "host3"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestErrorsSummariesQuery_Account_SpecificErrors(t *testing.T) {
+	baseQuery := BASE_QUERY_ACCOUNT
+	groupBy := GROUP_BY_ACCOUNT
+
+	// Generate by account with defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "no",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific accounts by user
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_EXCLUDE: "",
+			OPT_INCLUDE: "user1@*,user2@*",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND (USER IN (?, ?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including a combination of user/host, users, hosts, and invalid inputs
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_INCLUDE: "user1@host1,user3@*,user2@host2,*@host3,*@*,invalid",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_ACCOUNT)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER, HOST FROM performance_schema.events_errors_summary_by_account_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND ((USER, HOST) IN ((?, ?), (?, ?)) OR USER IN (?) OR HOST IN (?)) AND USER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "user1", "host1", "user2", "host2", "user3", "host3"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestErrorsSummariesQuery_Global(t *testing.T) {
+	baseQuery := BASE_QUERY_GLOBAL
+	groupBy := GROUP_BY_GLOBAL
+
+	// All defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_GLOBAL)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME FROM performance_schema.events_errors_summary_global_by_error WHERE ERROR_NUMBER IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Specific errors with defaults
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "no",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_GLOBAL)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME FROM performance_schema.events_errors_summary_global_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Exclude specific errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "exclude",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_GLOBAL)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME FROM performance_schema.events_errors_summary_global_by_error WHERE (ERROR_NUMBER NOT IN (?) AND ERROR_NAME NOT IN (?)) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Collect all error and emit only the total
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "only",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_GLOBAL)
+	expect = "SELECT SUM(SUM_ERROR_RAISED), '' ERROR_NUMBER, '' ERROR_NAME FROM performance_schema.events_errors_summary_global_by_error WHERE ERROR_NUMBER IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestErrorsSummariesQuery_Host(t *testing.T) {
+	baseQuery := BASE_QUERY_HOST
+	groupBy := GROUP_BY_HOST
+
+	// Generate by host with defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_HOST)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error WHERE ERROR_NUMBER IS NOT NULL AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Generate by host with specific errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "no",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_HOST)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND HOST IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific hosts
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_EXCLUDE: "event_scheduler",
+			OPT_INCLUDE: "host1,host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_HOST)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND HOST IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "host1", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific hosts but all errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "all",
+			OPT_EXCLUDE: "event_scheduler",
+			OPT_INCLUDE: "host1,host2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_HOST)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error WHERE ERROR_NUMBER IS NOT NULL AND HOST IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"host1", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific hosts but all errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "all",
+			OPT_EXCLUDE: "event_scheduler",
+			OPT_INCLUDE: "host1,host2",
+			OPT_TOTAL:   "only",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_HOST)
+	expect = "SELECT SUM(SUM_ERROR_RAISED), '' ERROR_NUMBER, '' ERROR_NAME, HOST FROM performance_schema.events_errors_summary_by_host_by_error WHERE ERROR_NUMBER IS NOT NULL AND HOST IN (?, ?) AND SUM_ERROR_RAISED > 0 GROUP BY HOST"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"host1", "host2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestErrorsSummariesQuery_User(t *testing.T) {
+	baseQuery := BASE_QUERY_USER
+	groupBy := GROUP_BY_USER
+
+	// Generate by user with defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_USER)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error WHERE ERROR_NUMBER IS NOT NULL AND USER IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Generate by user with specific errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "no",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_USER)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND USER IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific users
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_INCLUDE: "user1,user2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_USER)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND USER IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding specific users
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_EXCLUDE: "user1,user2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_USER)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND USER NOT IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific users and only emit totals
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "all",
+			OPT_INCLUDE: "user1,user2",
+			OPT_TOTAL:   "only",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_USER)
+	expect = "SELECT SUM(SUM_ERROR_RAISED), '' ERROR_NUMBER, '' ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error WHERE ERROR_NUMBER IS NOT NULL AND USER IN (?, ?) AND SUM_ERROR_RAISED > 0 GROUP BY USER"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"user1", "user2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestErrorsSummariesQuery_Thread(t *testing.T) {
+	baseQuery := BASE_QUERY_THREAD
+	groupBy := GROUP_BY_THREAD
+
+	// Generate by thread with defaults
+	dom := blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "yes",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{},
+	}
+
+	got, err := ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_THREAD)
+	expect := "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error WHERE ERROR_NUMBER IS NOT NULL AND THREAD_ID IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams := []any{}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Generate by thread with specific errors
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:   "no",
+			OPT_TOTAL: "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_THREAD)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND THREAD_ID IS NOT NULL AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific threads
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_INCLUDE: "1,2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_THREAD)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND THREAD_ID IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "1", "2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Excluding specific threads
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "no",
+			OPT_EXCLUDE: "1,2",
+			OPT_TOTAL:   "yes",
+		},
+		Metrics: []string{"3024", "ER_QUERY_TIMEOUT"},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_THREAD)
+	expect = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error WHERE (ERROR_NUMBER IN (?) OR ERROR_NAME IN (?)) AND THREAD_ID NOT IN (?, ?) AND SUM_ERROR_RAISED > 0"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{3024, "ER_QUERY_TIMEOUT", "1", "2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+
+	// Including specific threads and only emit totals
+	dom = blip.Domain{
+		Options: map[string]string{
+			OPT_ALL:     "all",
+			OPT_INCLUDE: "1,2",
+			OPT_TOTAL:   "only",
+		},
+		Metrics: []string{},
+	}
+
+	got, err = ErrorsQuery(dom, baseQuery, groupBy, SUB_DOMAIN_THREAD)
+	expect = "SELECT SUM(SUM_ERROR_RAISED), '' ERROR_NUMBER, '' ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error WHERE ERROR_NUMBER IS NOT NULL AND THREAD_ID IN (?, ?) AND SUM_ERROR_RAISED > 0 GROUP BY THREAD_ID"
+	if err != nil {
+		t.Error(err)
+	}
+	if got.query != expect {
+		t.Errorf("got:\n%s\nexpect:\n%s\n", got.query, expect)
+	}
+
+	expectedParams = []any{"1", "2"}
+	if diff := deep.Equal(got.params, expectedParams); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/metrics/error/thread.go
+++ b/metrics/error/thread.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cashapp/blip"
+)
+
+const (
+	TRUNCATE_QUERY_THREAD = "TRUNCATE TABLE performance_schema.events_errors_summary_by_thread_by_error"
+	BASE_QUERY_THREAD     = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, THREAD_ID FROM performance_schema.events_errors_summary_by_thread_by_error"
+	GROUP_BY_THREAD       = " GROUP BY THREAD_ID"
+)
+
+// ErrorThread collects error summary information for the error.thread domain.
+// https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html
+type ErrorThread struct {
+	db *sql.DB
+	// --
+	options map[string]*errorLevelOptions
+}
+
+// Verify collector implements blip.Collector interface.
+var _ blip.Collector = &ErrorThread{}
+
+// NewErrorThread makes a new Table collector,
+func NewErrorThread(db *sql.DB) *ErrorThread {
+	return &ErrorThread{
+		db:      db,
+		options: make(map[string]*errorLevelOptions),
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (t *ErrorThread) Domain() string {
+	return DOMAIN + "." + SUB_DOMAIN_THREAD
+}
+
+// Help returns the output for blip --print-domains.
+func (t *ErrorThread) Help() blip.CollectorHelp {
+	h := help(SUB_DOMAIN_THREAD)
+	h.Groups = append(h.Groups, []blip.CollectorKeyValue{
+		{Key: GRP_ERR_THREAD, Value: "the thread for the corresponding error"},
+	}...)
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name: OPT_INCLUDE,
+		Desc: fmt.Sprintf("Comma-separated list of threads to include (overrides option %s)", OPT_EXCLUDE),
+	}
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name:    OPT_EXCLUDE,
+		Desc:    fmt.Sprintf("Comma-separated list of threads to exclude (ignored if %s is set).", OPT_INCLUDE),
+		Default: "event_scheduler",
+	}
+
+	return h
+}
+
+// Prepare prepares the collector for the given plan.
+func (t *ErrorThread) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[t.Domain()]
+		if !ok {
+			continue
+		}
+		if dom.Options == nil {
+			dom.Options = make(map[string]string)
+		}
+
+		errOpts, err := prepare(dom, SUB_DOMAIN_THREAD, BASE_QUERY_THREAD, GROUP_BY_THREAD)
+		if err != nil {
+			return nil, err
+		}
+
+		t.options[level.Name] = errOpts
+
+		// Run an initial truncate to clear out any old data
+		if errOpts.truncateOnStartup {
+			err := t.truncate(ctx, level.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to truncate table for %s on level %s: %v", t.Domain(), level.Name, err)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (t *ErrorThread) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		metrics   []blip.MetricValue
+		errors    int64
+		errorNum  string
+		errorName string
+		thread    string
+		total     map[string]float64 = make(map[string]float64)
+	)
+
+	for rows.Next() {
+		if err = rows.Scan(&errors, &errorNum, &errorName, &thread); err != nil {
+			return nil, err
+		}
+
+		m := blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: errorNum, GRP_ERR_NAME: errorName, GRP_ERR_THREAD: thread},
+			Value: float64(errors),
+		}
+
+		metrics = append(metrics, m)
+
+		if _, ok := total[thread]; !ok {
+			total[thread] = 0
+		}
+		total[thread] += float64(errors)
+	}
+
+	if o.emitTotal {
+		for thread, value := range total {
+			metrics = append(metrics, blip.MetricValue{
+				Name:  "raised",
+				Type:  o.metricType,
+				Group: map[string]string{GRP_ERR_NUMBER: "", GRP_ERR_NAME: "", GRP_ERR_THREAD: thread},
+				Value: value,
+			})
+		}
+	}
+
+	if o.truncate {
+		err = t.truncate(ctx, levelName)
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
+		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
+	}
+
+	return metrics, err
+}
+
+func (t *ErrorThread) truncate(ctx context.Context, levelName string) error {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil
+	}
+
+	return truncate(ctx, t.db, o, TRUNCATE_QUERY_THREAD)
+}

--- a/metrics/error/user.go
+++ b/metrics/error/user.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Block, Inc.
+
+package error
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cashapp/blip"
+)
+
+const (
+	TRUNCATE_QUERY_USER = "TRUNCATE TABLE performance_schema.events_errors_summary_by_user_by_error"
+	BASE_QUERY_USER     = "SELECT SUM_ERROR_RAISED, ERROR_NUMBER, ERROR_NAME, USER FROM performance_schema.events_errors_summary_by_user_by_error"
+	GROUP_BY_USER       = " GROUP BY USER"
+)
+
+// ErrorUser collects error summary information for the error.user domain.
+// https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html
+type ErrorUser struct {
+	db *sql.DB
+	// --
+	options map[string]*errorLevelOptions
+}
+
+// Verify collector implements blip.Collector interface.
+var _ blip.Collector = &ErrorUser{}
+
+// NewErrorUser makes a new Table collector,
+func NewErrorUser(db *sql.DB) *ErrorUser {
+	return &ErrorUser{
+		db:      db,
+		options: make(map[string]*errorLevelOptions),
+	}
+}
+
+// Domain returns the Blip metric domain name (DOMAIN const).
+func (t *ErrorUser) Domain() string {
+	return DOMAIN + "." + SUB_DOMAIN_USER
+}
+
+// Help returns the output for blip --print-domains.
+func (t *ErrorUser) Help() blip.CollectorHelp {
+	h := help(SUB_DOMAIN_USER)
+	h.Groups = append(h.Groups, []blip.CollectorKeyValue{
+		{Key: GRP_ERR_USER, Value: "the user for the corresponding error"},
+	}...)
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name: OPT_INCLUDE,
+		Desc: fmt.Sprintf("Comma-separated list of users to include (overrides option %s)", OPT_EXCLUDE),
+	}
+	h.Options[OPT_INCLUDE] = blip.CollectorHelpOption{
+		Name:    OPT_EXCLUDE,
+		Desc:    fmt.Sprintf("Comma-separated list of users to exclude (ignored if %s is set).", OPT_INCLUDE),
+		Default: "event_scheduler",
+	}
+
+	return h
+}
+
+// Prepare prepares the collector for the given plan.
+func (t *ErrorUser) Prepare(ctx context.Context, plan blip.Plan) (func(), error) {
+	for _, level := range plan.Levels {
+		dom, ok := level.Collect[t.Domain()]
+		if !ok {
+			continue
+		}
+		if dom.Options == nil {
+			dom.Options = make(map[string]string)
+		}
+
+		errOpts, err := prepare(dom, SUB_DOMAIN_USER, BASE_QUERY_USER, GROUP_BY_USER)
+		if err != nil {
+			return nil, err
+		}
+
+		t.options[level.Name] = errOpts
+
+		// Run an initial truncate to clear out any old data
+		if errOpts.truncateOnStartup {
+			err := t.truncate(ctx, level.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to truncate table for %s on level %s: %v", t.Domain(), level.Name, err)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (t *ErrorUser) Collect(ctx context.Context, levelName string) ([]blip.MetricValue, error) {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := t.db.QueryContext(ctx, o.query, o.params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		metrics   []blip.MetricValue
+		errors    int64
+		errorNum  string
+		errorName string
+		user      string
+		total     map[string]float64 = make(map[string]float64)
+	)
+
+	for rows.Next() {
+		if err = rows.Scan(&errors, &errorNum, &errorName, &user); err != nil {
+			return nil, err
+		}
+
+		m := blip.MetricValue{
+			Name:  "raised",
+			Type:  o.metricType,
+			Group: map[string]string{GRP_ERR_NUMBER: errorNum, GRP_ERR_NAME: errorName, GRP_ERR_USER: user},
+			Value: float64(errors),
+		}
+
+		metrics = append(metrics, m)
+
+		if _, ok := total[user]; !ok {
+			total[user] = 0
+		}
+		total[user] += float64(errors)
+	}
+
+	if o.emitTotal {
+		for user, value := range total {
+			metrics = append(metrics, blip.MetricValue{
+				Name:  "raised",
+				Type:  o.metricType,
+				Group: map[string]string{GRP_ERR_NUMBER: "", GRP_ERR_NAME: "", GRP_ERR_USER: user},
+				Value: value,
+			})
+		}
+	}
+
+	if o.truncate {
+		err = t.truncate(ctx, levelName)
+		// Process any errors (or lack thereof) with the TruncateErrorPolicy as there is special handling
+		// for the metric values that need to be applied, even if there is not an error. See comments
+		// in `TruncateErrorPolicy` for more details.
+		return o.truncateErrPolicy.TruncateError(err, &o.stop, metrics)
+	}
+
+	return metrics, err
+}
+
+func (t *ErrorUser) truncate(ctx context.Context, levelName string) error {
+	o, ok := t.options[levelName]
+	if !ok {
+		return nil
+	}
+
+	return truncate(ctx, t.db, o, TRUNCATE_QUERY_USER)
+}

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cashapp/blip"
 	"github.com/cashapp/blip/metrics/autoinc"
 	awsrds "github.com/cashapp/blip/metrics/aws.rds"
+	errordomain "github.com/cashapp/blip/metrics/error"
 	"github.com/cashapp/blip/metrics/innodb"
 	innodbbufferpool "github.com/cashapp/blip/metrics/innodb.buffer-pool"
 	"github.com/cashapp/blip/metrics/percona"
@@ -262,6 +263,16 @@ func (f *factory) Make(domain string, args blip.CollectorFactoryArgs) (blip.Coll
 			return nil, err
 		}
 		return awsrds.NewRDS(awsrds.NewCloudWatchClient(awsConfig)), nil
+	case "error.account":
+		return errordomain.NewErrorAccount(args.DB), nil
+	case "error.global":
+		return errordomain.NewErrorGlobal(args.DB), nil
+	case "error.host":
+		return errordomain.NewErrorHost(args.DB), nil
+	case "error.thread":
+		return errordomain.NewErrorThread(args.DB), nil
+	case "error.user":
+		return errordomain.NewErrorUser(args.DB), nil
 	case "innodb":
 		return innodb.NewInnoDB(args.DB), nil
 	case "innodb.buffer-pool":
@@ -301,6 +312,11 @@ func (f *factory) Make(domain string, args blip.CollectorFactoryArgs) (blip.Coll
 var builtinCollectors = []string{
 	"autoinc",
 	"aws.rds",
+	"error.account",
+	"error.global",
+	"error.host",
+	"error.thread",
+	"error.user",
 	"innodb",
 	"innodb.buffer-pool",
 	"percona.response-time",

--- a/metrics/size.database/database.go
+++ b/metrics/size.database/database.go
@@ -54,7 +54,7 @@ func (c *Database) Help() blip.CollectorHelp {
 				Desc:    "Return total size of all databases",
 				Default: "no",
 				Values: map[string]string{
-					"only": "Only total database size)",
+					"only": "Only total database size",
 					"yes":  "Total and per-database sizes",
 					"no":   "Only per-database sizes",
 				},

--- a/sqlutil/sqlutil.go
+++ b/sqlutil/sqlutil.go
@@ -69,6 +69,21 @@ func PlaceholderList(count int) string {
 	return fmt.Sprintf("?%s", strings.Repeat(", ?", count-1))
 }
 
+func MultiPlaceholderList(count int, tupleLength int) string {
+	if tupleLength == 1 {
+		return PlaceholderList(count)
+	}
+
+	if count <= 0 {
+		return ""
+	} else if tupleLength <= 0 {
+		return ""
+	}
+
+	tuple := fmt.Sprintf("(?%s)", strings.Repeat(", ?", tupleLength-1))
+	return fmt.Sprintf("%s%s", tuple, strings.Repeat(", "+tuple, count-1))
+}
+
 // ToInterfaceArray converts a list of any type to a list of interface{}.
 func ToInterfaceArray[T any](list []T) []interface{} {
 	if len(list) == 0 {


### PR DESCRIPTION
Adding the `metrics/error` package that includes the following domains:
- `error.global`
- `error.account`
- `error.host`
- `error.thread`
- `error.user`

These domains emit metrics on errors from the error summary tables (https://dev.mysql.com/doc/refman/en/performance-schema-error-summary-tables.html) See the documentation for more details.